### PR TITLE
Filter user list by private channel permissions

### DIFF
--- a/functions/filter_users_private_channel_permission/mod.ts
+++ b/functions/filter_users_private_channel_permission/mod.ts
@@ -1,0 +1,255 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+import { channelIdSchema } from "../../lib/validation/schemas.ts";
+
+// i18nを初期化
+await initI18n();
+
+/**
+ * Admin API から取得するユーザー情報の型
+ */
+interface AdminUser {
+  id: string;
+  email?: string;
+  is_admin?: boolean;
+  is_owner?: boolean;
+  is_primary_owner?: boolean;
+  is_restricted?: boolean;
+  is_ultra_restricted?: boolean;
+  is_bot?: boolean;
+  deleted?: boolean;
+}
+
+/**
+ * admin.users.list API レスポンスの型
+ */
+interface AdminUsersListResponse {
+  ok: boolean;
+  users?: AdminUser[];
+  next_cursor?: string;
+  error?: string;
+}
+
+/**
+ * プライベートチャンネル作成権限を持つユーザーをフィルタリングする関数の定義
+ *
+ * Admin API を使用してワークスペースのユーザーリストを取得し、
+ * プライベートチャンネル作成権限を持つユーザーのみを返します。
+ */
+export const FilterUsersPrivateChannelPermissionDefinition = DefineFunction({
+  callback_id: "filter_users_private_channel_permission",
+  title: "Filter Users with Private Channel Permission",
+  description:
+    "Filter users who have permission to create private channels using Admin API",
+  source_file: "functions/filter_users_private_channel_permission/mod.ts",
+  input_parameters: {
+    properties: {
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description:
+          "Channel ID to get workspace team_id (any channel in the workspace)",
+      },
+    },
+    required: ["channel_id"],
+  },
+  output_parameters: {
+    properties: {
+      user_ids: {
+        type: Schema.types.array,
+        items: {
+          type: Schema.slack.types.user_id,
+        },
+        description: "User IDs who have permission to create private channels",
+      },
+      user_count: {
+        type: Schema.types.integer,
+        description: "Number of users with permission",
+      },
+    },
+    required: ["user_ids", "user_count"],
+  },
+});
+
+/**
+ * ワークスペースの team_id を取得します
+ *
+ * @param client - Slack APIクライアント
+ * @param channelId - ワークスペース内の任意のチャンネルID
+ * @returns ワークスペースのteam_id
+ * @throws {Error} チャンネル情報の取得に失敗した場合
+ */
+async function getWorkspaceTeamId(
+  // deno-lint-ignore no-explicit-any
+  client: any,
+  channelId: string,
+): Promise<string> {
+  const response = await client.conversations.info({ channel: channelId });
+
+  if (!response.ok || !response.channel) {
+    throw new Error(
+      t("errors.channel_info_failed", {
+        error: response.error ?? t("errors.unknown_error"),
+      }),
+    );
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const teamId = (response.channel as any).context_team_id as string;
+
+  if (!teamId) {
+    throw new Error(t("errors.missing_team_id"));
+  }
+
+  return teamId;
+}
+
+/**
+ * Admin API を使用してワークスペースのユーザーリストを取得します
+ *
+ * @param adminToken - 管理者のユーザートークン（xoxp-...）
+ * @param teamId - ワークスペースのチームID
+ * @returns ユーザーリスト
+ * @throws {Error} ユーザーリストの取得に失敗した場合
+ */
+export async function fetchWorkspaceUsers(
+  adminToken: string,
+  teamId: string,
+): Promise<AdminUser[]> {
+  const allUsers: AdminUser[] = [];
+  let cursor: string | undefined;
+
+  console.log(t("logs.fetching_workspace_users", { teamId }));
+
+  do {
+    const params = new URLSearchParams({
+      team_id: teamId,
+      limit: "200",
+    });
+
+    if (cursor) {
+      params.append("cursor", cursor);
+    }
+
+    const response = await fetch(
+      `https://slack.com/api/admin.users.list?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${adminToken}`,
+          "Content-Type": "application/json; charset=utf-8",
+        },
+      },
+    );
+
+    const result: AdminUsersListResponse = await response.json();
+
+    console.log("admin.users.list response:", {
+      ok: result.ok,
+      error: result.error,
+      user_count: result.users?.length ?? 0,
+      has_next_cursor: !!result.next_cursor,
+    });
+
+    if (!result.ok) {
+      throw new Error(
+        t("errors.users_list_failed", {
+          error: result.error ?? t("errors.unknown_error"),
+        }),
+      );
+    }
+
+    if (result.users) {
+      allUsers.push(...result.users);
+    }
+
+    cursor = result.next_cursor;
+  } while (cursor);
+
+  console.log(t("logs.users_fetched", { count: allUsers.length }));
+
+  return allUsers;
+}
+
+/**
+ * プライベートチャンネル作成権限を持つユーザーをフィルタリングします
+ *
+ * フィルタリング条件:
+ * - is_admin = true（管理者）
+ * - is_owner = true（オーナー）
+ * - is_primary_owner = true（プライマリオーナー）
+ * - かつ、削除済み・制限付き・ボットではないこと
+ *
+ * @param users - ワークスペースのユーザーリスト
+ * @returns プライベートチャンネル作成権限を持つユーザーIDの配列
+ */
+export function filterUsersWithPrivateChannelPermission(
+  users: AdminUser[],
+): string[] {
+  return users
+    .filter((user) => {
+      // 削除済みユーザーを除外
+      if (user.deleted) {
+        return false;
+      }
+
+      // ボットを除外
+      if (user.is_bot) {
+        return false;
+      }
+
+      // 制限付きユーザー（ゲスト）を除外
+      if (user.is_restricted || user.is_ultra_restricted) {
+        return false;
+      }
+
+      // 管理者、オーナー、プライマリオーナーのみを含める
+      return user.is_admin || user.is_owner || user.is_primary_owner;
+    })
+    .map((user) => user.id);
+}
+
+export default SlackFunction(
+  FilterUsersPrivateChannelPermissionDefinition,
+  async ({ inputs, client, env }) => {
+    try {
+      // バリデーション
+      const channelId = channelIdSchema.parse(inputs.channel_id);
+
+      // 環境変数から Admin User Token を取得
+      const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+
+      if (!adminToken) {
+        throw new Error(t("errors.missing_admin_token"));
+      }
+
+      // ワークスペースの team_id を取得
+      const teamId = await getWorkspaceTeamId(client, channelId);
+
+      console.log(t("logs.filtering_users_with_permission", { teamId }));
+
+      // Admin API でユーザーリストを取得
+      const users = await fetchWorkspaceUsers(adminToken, teamId);
+
+      // プライベートチャンネル作成権限を持つユーザーをフィルタリング
+      const filteredUserIds = filterUsersWithPrivateChannelPermission(users);
+
+      console.log(
+        t("logs.users_filtered", {
+          total: users.length,
+          filtered: filteredUserIds.length,
+        }),
+      );
+
+      return {
+        outputs: {
+          user_ids: filteredUserIds,
+          user_count: filteredUserIds.length,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      console.error("Function error:", message);
+      return { error: message };
+    }
+  },
+);

--- a/functions/filter_users_private_channel_permission/test.ts
+++ b/functions/filter_users_private_channel_permission/test.ts
@@ -1,0 +1,194 @@
+import { assertEquals } from "std/testing/asserts.ts";
+import { filterUsersWithPrivateChannelPermission } from "./mod.ts";
+// i18n is auto-initialized when imported
+
+/**
+ * Admin API から取得するユーザー情報の型（テスト用）
+ */
+interface AdminUser {
+  id: string;
+  email?: string;
+  is_admin?: boolean;
+  is_owner?: boolean;
+  is_primary_owner?: boolean;
+  is_restricted?: boolean;
+  is_ultra_restricted?: boolean;
+  is_bot?: boolean;
+  deleted?: boolean;
+}
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 管理者のみをフィルタリングする",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: true },
+      { id: "U002", is_admin: false },
+      { id: "U003", is_admin: true },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001", "U003"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: オーナーをフィルタリングする",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_owner: true },
+      { id: "U002", is_owner: false },
+      { id: "U003", is_owner: true },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001", "U003"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: プライマリオーナーをフィルタリングする",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_primary_owner: true },
+      { id: "U002", is_primary_owner: false },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 管理者・オーナー・プライマリオーナーの全てをフィルタリングする",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: true },
+      { id: "U002", is_owner: true },
+      { id: "U003", is_primary_owner: true },
+      { id: "U004" }, // 一般ユーザー
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001", "U002", "U003"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 削除済みユーザーを除外する",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: true, deleted: false },
+      { id: "U002", is_admin: true, deleted: true },
+      { id: "U003", is_owner: true, deleted: true },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: ボットを除外する",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: true, is_bot: false },
+      { id: "B001", is_admin: true, is_bot: true },
+      { id: "U002", is_owner: true, is_bot: true },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 制限付きユーザー（ゲスト）を除外する",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: true, is_restricted: false },
+      { id: "U002", is_admin: true, is_restricted: true },
+      { id: "U003", is_owner: true, is_ultra_restricted: true },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 権限のあるユーザーがいない場合は空配列を返す",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: false },
+      { id: "U002", is_owner: false },
+      { id: "U003" },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, []);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 空のユーザーリストに対しては空配列を返す",
+  fn: () => {
+    const users: AdminUser[] = [];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, []);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 複合条件（管理者かつオーナー）も正しくフィルタリングする",
+  fn: () => {
+    const users: AdminUser[] = [
+      { id: "U001", is_admin: true, is_owner: true, is_primary_owner: false },
+      { id: "U002", is_admin: false, is_owner: false, is_primary_owner: false },
+      {
+        id: "U003",
+        is_admin: true,
+        is_owner: false,
+        is_primary_owner: false,
+        deleted: true,
+      },
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001"]);
+  },
+});
+
+Deno.test({
+  name: "filterUsersWithPrivateChannelPermission: 全ての除外条件を複合的にテストする",
+  fn: () => {
+    const users: AdminUser[] = [
+      // 含まれるべきユーザー
+      { id: "U001", is_admin: true },
+      { id: "U002", is_owner: true },
+      { id: "U003", is_primary_owner: true },
+      // 除外されるべきユーザー
+      { id: "U004" }, // 一般ユーザー
+      { id: "U005", is_admin: true, deleted: true }, // 削除済み
+      { id: "U006", is_admin: true, is_bot: true }, // ボット
+      { id: "U007", is_admin: true, is_restricted: true }, // ゲスト
+      { id: "U008", is_owner: true, is_ultra_restricted: true }, // シングルチャンネルゲスト
+      { id: "U009", is_admin: false, is_owner: false }, // 権限なし
+    ];
+
+    const result = filterUsersWithPrivateChannelPermission(users);
+
+    assertEquals(result, ["U001", "U002", "U003"]);
+    assertEquals(result.length, 3);
+  },
+});

--- a/functions/filter_users_private_channel_permission/test.ts
+++ b/functions/filter_users_private_channel_permission/test.ts
@@ -18,7 +18,8 @@ interface AdminUser {
 }
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 管理者のみをフィルタリングする",
+  name:
+    "filterUsersWithPrivateChannelPermission: 管理者のみをフィルタリングする",
   fn: () => {
     const users: AdminUser[] = [
       { id: "U001", is_admin: true },
@@ -48,7 +49,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: プライマリオーナーをフィルタリングする",
+  name:
+    "filterUsersWithPrivateChannelPermission: プライマリオーナーをフィルタリングする",
   fn: () => {
     const users: AdminUser[] = [
       { id: "U001", is_primary_owner: true },
@@ -62,7 +64,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 管理者・オーナー・プライマリオーナーの全てをフィルタリングする",
+  name:
+    "filterUsersWithPrivateChannelPermission: 管理者・オーナー・プライマリオーナーの全てをフィルタリングする",
   fn: () => {
     const users: AdminUser[] = [
       { id: "U001", is_admin: true },
@@ -108,7 +111,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 制限付きユーザー（ゲスト）を除外する",
+  name:
+    "filterUsersWithPrivateChannelPermission: 制限付きユーザー（ゲスト）を除外する",
   fn: () => {
     const users: AdminUser[] = [
       { id: "U001", is_admin: true, is_restricted: false },
@@ -123,7 +127,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 権限のあるユーザーがいない場合は空配列を返す",
+  name:
+    "filterUsersWithPrivateChannelPermission: 権限のあるユーザーがいない場合は空配列を返す",
   fn: () => {
     const users: AdminUser[] = [
       { id: "U001", is_admin: false },
@@ -138,7 +143,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 空のユーザーリストに対しては空配列を返す",
+  name:
+    "filterUsersWithPrivateChannelPermission: 空のユーザーリストに対しては空配列を返す",
   fn: () => {
     const users: AdminUser[] = [];
 
@@ -149,7 +155,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 複合条件（管理者かつオーナー）も正しくフィルタリングする",
+  name:
+    "filterUsersWithPrivateChannelPermission: 複合条件（管理者かつオーナー）も正しくフィルタリングする",
   fn: () => {
     const users: AdminUser[] = [
       { id: "U001", is_admin: true, is_owner: true, is_primary_owner: false },
@@ -170,7 +177,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "filterUsersWithPrivateChannelPermission: 全ての除外条件を複合的にテストする",
+  name:
+    "filterUsersWithPrivateChannelPermission: 全ての除外条件を複合的にテストする",
   fn: () => {
     const users: AdminUser[] = [
       // 含まれるべきユーザー

--- a/lib/i18n/mod.ts
+++ b/lib/i18n/mod.ts
@@ -44,6 +44,7 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
         "Admin user token (SLACK_ADMIN_USER_TOKEN) is not configured",
       not_authorized_approver:
         "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
+      users_list_failed: "Failed to fetch users list: {error}",
       validation: {
         channel_id_empty: "Channel ID cannot be empty",
         channel_id_format:
@@ -97,6 +98,12 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       creating_channel_after_approval:
         "Creating channel '{name}' after approval",
       members_invited: "{count} members invited to the channel",
+      fetching_workspace_users: "Fetching workspace users for team: {teamId}",
+      users_fetched: "Fetched {count} users from workspace",
+      filtering_users_with_permission:
+        "Filtering users with private channel permission for team: {teamId}",
+      users_filtered:
+        "Filtered {filtered} users with permission out of {total} total users",
     },
   },
   ja: {
@@ -125,6 +132,7 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
         "管理者ユーザートークン（SLACK_ADMIN_USER_TOKEN）が設定されていません",
       not_authorized_approver:
         "⚠️ このリクエストを承認する権限がありません。<@{approver}> のみが承認または拒否できます。",
+      users_list_failed: "ユーザーリストの取得に失敗しました: {error}",
       validation: {
         channel_id_empty: "チャンネルIDを空にすることはできません",
         channel_id_format:
@@ -179,6 +187,13 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       approval_request_sent: "承認リクエストを送信しました",
       creating_channel_after_approval: "承認後にチャンネル '{name}' を作成中",
       members_invited: "{count} 人のメンバーを招待しました",
+      fetching_workspace_users:
+        "チーム {teamId} のワークスペースユーザーを取得中",
+      users_fetched: "ワークスペースから {count} 人のユーザーを取得しました",
+      filtering_users_with_permission:
+        "チーム {teamId} のプライベートチャンネル作成権限を持つユーザーをフィルタリング中",
+      users_filtered:
+        "合計 {total} 人のユーザーから {filtered} 人の権限を持つユーザーをフィルタリングしました",
     },
   },
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,6 +19,7 @@
     "missing_notification_channel": "Notification channel ID is required",
     "missing_admin_token": "Admin user token (SLACK_ADMIN_USER_TOKEN) is not configured",
     "not_authorized_approver": "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
+    "users_list_failed": "Failed to fetch users list: {error}",
     "validation": {
       "channel_id_empty": "Channel ID cannot be empty",
       "channel_id_format": "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
@@ -62,6 +63,10 @@
     "sending_approval_request": "Sending approval request for channel '{channel}' to approver '{approver}'",
     "approval_request_sent": "Approval request sent successfully",
     "creating_channel_after_approval": "Creating channel '{name}' after approval",
-    "members_invited": "{count} members invited to the channel"
+    "members_invited": "{count} members invited to the channel",
+    "fetching_workspace_users": "Fetching workspace users for team: {teamId}",
+    "users_fetched": "Fetched {count} users from workspace",
+    "filtering_users_with_permission": "Filtering users with private channel permission for team: {teamId}",
+    "users_filtered": "Filtered {filtered} users with permission out of {total} total users"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -19,6 +19,7 @@
     "missing_notification_channel": "通知チャネルIDが必要です",
     "missing_admin_token": "管理者ユーザートークン(SLACK_ADMIN_USER_TOKEN)が設定されていません",
     "not_authorized_approver": "⚠️ このリクエストを承認する権限がありません。<@{approver}>のみが承認または却下できます。",
+    "users_list_failed": "ユーザーリストの取得に失敗しました: {error}",
     "validation": {
       "channel_id_empty": "チャネルIDを空にすることはできません",
       "channel_id_format": "チャネルIDは'C'で始まり、その後に大文字の英数字が続く必要があります",
@@ -62,6 +63,10 @@
     "sending_approval_request": "チャネル'{channel}'の承認リクエストを承認者'{approver}'に送信中です",
     "approval_request_sent": "承認リクエストが正常に送信されました",
     "creating_channel_after_approval": "承認後、チャネル'{name}'を作成中です",
-    "members_invited": "{count}人のメンバーがチャネルに招待されました"
+    "members_invited": "{count}人のメンバーがチャネルに招待されました",
+    "fetching_workspace_users": "チーム{teamId}のワークスペースユーザーを取得中です",
+    "users_fetched": "ワークスペースから{count}人のユーザーを取得しました",
+    "filtering_users_with_permission": "チーム{teamId}のプライベートチャネル作成権限を持つユーザーをフィルタリング中です",
+    "users_filtered": "合計{total}人のユーザーから{filtered}人の権限を持つユーザーをフィルタリングしました"
   }
 }

--- a/manifest.ts
+++ b/manifest.ts
@@ -3,6 +3,7 @@ import { ExampleFunctionDefinition } from "./functions/example_function/mod.ts";
 import { GetChannelMembersDefinition } from "./functions/get_channel_members/mod.ts";
 import { CreatePrivateChannelDefinition } from "./functions/create_private_channel/mod.ts";
 import { RequestPrivateChannelDefinition } from "./functions/request_private_channel/mod.ts";
+import { FilterUsersPrivateChannelPermissionDefinition } from "./functions/filter_users_private_channel_permission/mod.ts";
 import CreateChannelWorkflow from "./workflows/create_channel_workflow.ts";
 import RequestPrivateChannelWorkflow from "./workflows/request_private_channel_workflow.ts";
 import ExampleWorkflow from "./workflows/example_workflow.ts";
@@ -28,6 +29,7 @@ export default Manifest({
     GetChannelMembersDefinition,
     CreatePrivateChannelDefinition,
     RequestPrivateChannelDefinition,
+    FilterUsersPrivateChannelPermissionDefinition,
   ],
   outgoingDomains: [], // slack.com はデフォルトで許可済み
   botScopes: [


### PR DESCRIPTION
Add a new function to filter users who have permission to create private channels using Admin API (admin.users.list).

Features:
- Filter users based on is_admin, is_owner, or is_primary_owner flags
- Exclude deleted users, bots, and restricted (guest) users
- Paginated API calls to handle large workspaces
- Full i18n support for error and log messages

Required scope: admin.users:read (via separate Slack app with user token)

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
