### PR TITLE
feat: enhance private channel request workflow with authorized user type

### DIFF
--- a/functions/get_authorized_users/mod.ts
+++ b/functions/get_authorized_users/mod.ts
@@ -1,6 +1,7 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 import { initI18n, t } from "../../lib/i18n/mod.ts";
 import { channelIdSchema } from "../../lib/validation/schemas.ts";
+import { AuthorizedUserType } from "../../lib/types/authorized_user.ts";
 
 // i18nを初期化
 await initI18n();
@@ -24,13 +25,15 @@ interface AdminUsersListResponse {
   ok: boolean;
   users?: Array<{
     id: string;
-    name?: string;
-    real_name?: string;
+    username?: string;
+    full_name?: string;
+    email?: string;
     is_admin?: boolean;
     is_owner?: boolean;
     is_primary_owner?: boolean;
     is_bot?: boolean;
     deleted?: boolean;
+    is_active?: boolean;
     is_restricted?: boolean;
     is_ultra_restricted?: boolean;
   }>;
@@ -54,29 +57,28 @@ export const GetAuthorizedUsersDefinition = DefineFunction({
   source_file: "functions/get_authorized_users/mod.ts",
   input_parameters: {
     properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "Interactivity context (passed through to output)",
+      },
       channel_id: {
         type: Schema.slack.types.channel_id,
         description:
           "Channel ID to get workspace team_id (for Enterprise Grid)",
       },
     },
-    required: ["channel_id"],
+    required: ["interactivity", "channel_id"],
   },
   output_parameters: {
     properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "Interactivity context (passed through from input)",
+      },
       authorized_users: {
         type: Schema.types.array,
         items: {
-          type: Schema.types.object,
-          properties: {
-            id: { type: Schema.types.string },
-            name: { type: Schema.types.string },
-            real_name: { type: Schema.types.string },
-            is_admin: { type: Schema.types.boolean },
-            is_owner: { type: Schema.types.boolean },
-            is_primary_owner: { type: Schema.types.boolean },
-          },
-          required: ["id", "name", "real_name", "is_admin", "is_owner"],
+          type: AuthorizedUserType,
         },
         description: "List of users with private channel creation permission",
       },
@@ -90,7 +92,7 @@ export const GetAuthorizedUsersDefinition = DefineFunction({
         description: "Number of authorized users",
       },
     },
-    required: ["authorized_users", "user_ids", "count"],
+    required: ["interactivity", "authorized_users", "user_ids", "count"],
   },
 });
 
@@ -150,7 +152,19 @@ export async function getAuthorizedUsersWithAdminApi(
   const authorizedUsers: AuthorizedUser[] = [];
   let cursor: string | undefined;
 
+  // 無限ループを防ぐための最大ページ数制限
+  const MAX_PAGES = 50;
+  let pageCount = 0;
+
   do {
+    pageCount++;
+    if (pageCount > MAX_PAGES) {
+      console.warn(
+        t("logs.max_page_limit_reached", { limit: MAX_PAGES }),
+      );
+      break;
+    }
+
     const params = new URLSearchParams({
       team_id: teamId,
       limit: "200",
@@ -173,11 +187,15 @@ export async function getAuthorizedUsersWithAdminApi(
 
     const result: AdminUsersListResponse = await response.json();
 
+    // カーソル値をログに出力してデバッグを容易にする
+    const nextCursor = result.response_metadata?.next_cursor;
     console.log("admin.users.list response:", {
       ok: result.ok,
       error: result.error,
       user_count: result.users?.length ?? 0,
-      has_next_cursor: !!result.response_metadata?.next_cursor,
+      has_next_cursor: !!nextCursor,
+      cursor_value: nextCursor ? nextCursor.substring(0, 20) + "..." : "none",
+      page: pageCount,
     });
 
     if (!result.ok) {
@@ -191,16 +209,24 @@ export async function getAuthorizedUsersWithAdminApi(
     if (result.users) {
       for (const user of result.users) {
         // ボット、削除済み、ゲストユーザーを除外
-        if (user.is_bot || user.deleted || user.is_restricted || user.is_ultra_restricted) {
+        if (
+          user.is_bot || user.deleted || user.is_restricted ||
+          user.is_ultra_restricted
+        ) {
           continue;
         }
 
-        // 管理者またはオーナーのみを抽出
+        // 管理者またはオーナーのみを抽出（重複を防ぐ）
         if (user.is_admin || user.is_owner || user.is_primary_owner) {
+          // 既に追加済みのユーザーはスキップ
+          if (authorizedUsers.some((u) => u.id === user.id)) {
+            continue;
+          }
+
           authorizedUsers.push({
             id: user.id,
-            name: user.name ?? "",
-            real_name: user.real_name ?? "",
+            name: user.username ?? "",
+            real_name: user.full_name ?? "",
             is_admin: user.is_admin ?? false,
             is_owner: user.is_owner ?? false,
             is_primary_owner: user.is_primary_owner ?? false,
@@ -209,8 +235,13 @@ export async function getAuthorizedUsersWithAdminApi(
       }
     }
 
-    cursor = result.response_metadata?.next_cursor;
-  } while (cursor);
+    // カーソルチェックの改善: 空文字列、undefined、同じカーソルの場合はループ終了
+    const newCursor = result.response_metadata?.next_cursor;
+    if (!newCursor || newCursor === "" || newCursor === cursor) {
+      break;
+    }
+    cursor = newCursor;
+  } while (true);
 
   console.log(
     t("logs.authorized_users_fetched", { count: authorizedUsers.length }),
@@ -247,6 +278,7 @@ export default SlackFunction(
 
       return {
         outputs: {
+          interactivity: inputs.interactivity,
           authorized_users: authorizedUsers,
           user_ids: userIds,
           count: authorizedUsers.length,

--- a/functions/get_authorized_users/mod.ts
+++ b/functions/get_authorized_users/mod.ts
@@ -1,0 +1,261 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+import { channelIdSchema } from "../../lib/validation/schemas.ts";
+
+// i18nを初期化
+await initI18n();
+
+/**
+ * 認可ユーザー情報の型定義
+ */
+export interface AuthorizedUser {
+  id: string;
+  name: string;
+  real_name: string;
+  is_admin: boolean;
+  is_owner: boolean;
+  is_primary_owner: boolean;
+}
+
+/**
+ * admin.users.list APIのレスポンス型
+ */
+interface AdminUsersListResponse {
+  ok: boolean;
+  users?: Array<{
+    id: string;
+    name?: string;
+    real_name?: string;
+    is_admin?: boolean;
+    is_owner?: boolean;
+    is_primary_owner?: boolean;
+    is_bot?: boolean;
+    deleted?: boolean;
+    is_restricted?: boolean;
+    is_ultra_restricted?: boolean;
+  }>;
+  response_metadata?: {
+    next_cursor?: string;
+  };
+  error?: string;
+}
+
+/**
+ * プライベートチャンネル作成権限を持つユーザーを取得する関数の定義
+ *
+ * Admin API (admin.users.list) を使用して、
+ * 管理者(is_admin)またはオーナー(is_owner)のユーザーをフィルタリングします。
+ */
+export const GetAuthorizedUsersDefinition = DefineFunction({
+  callback_id: "get_authorized_users",
+  title: "Get Authorized Users",
+  description:
+    "Get users who have permission to create private channels (admins and owners)",
+  source_file: "functions/get_authorized_users/mod.ts",
+  input_parameters: {
+    properties: {
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description:
+          "Channel ID to get workspace team_id (for Enterprise Grid)",
+      },
+    },
+    required: ["channel_id"],
+  },
+  output_parameters: {
+    properties: {
+      authorized_users: {
+        type: Schema.types.array,
+        items: {
+          type: Schema.types.object,
+          properties: {
+            id: { type: Schema.types.string },
+            name: { type: Schema.types.string },
+            real_name: { type: Schema.types.string },
+            is_admin: { type: Schema.types.boolean },
+            is_owner: { type: Schema.types.boolean },
+            is_primary_owner: { type: Schema.types.boolean },
+          },
+          required: ["id", "name", "real_name", "is_admin", "is_owner"],
+        },
+        description: "List of users with private channel creation permission",
+      },
+      user_ids: {
+        type: Schema.types.array,
+        items: { type: Schema.slack.types.user_id },
+        description: "List of user IDs with permission",
+      },
+      count: {
+        type: Schema.types.integer,
+        description: "Number of authorized users",
+      },
+    },
+    required: ["authorized_users", "user_ids", "count"],
+  },
+});
+
+/**
+ * ワークスペースの team_id を取得します
+ *
+ * @param client - Slack APIクライアント
+ * @param channelId - チャンネルID
+ * @returns ワークスペースのteam_id
+ * @throws {Error} チャンネル情報の取得に失敗した場合
+ */
+async function getWorkspaceTeamId(
+  // deno-lint-ignore no-explicit-any
+  client: any,
+  channelId: string,
+): Promise<string> {
+  const response = await client.conversations.info({ channel: channelId });
+
+  if (!response.ok || !response.channel) {
+    throw new Error(
+      t("errors.channel_info_failed", {
+        error: response.error ?? t("errors.unknown_error"),
+      }),
+    );
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const teamId = (response.channel as any).context_team_id as string;
+
+  if (!teamId) {
+    throw new Error(t("errors.missing_team_id"));
+  }
+
+  return teamId;
+}
+
+/**
+ * Admin API を使用してプライベートチャンネル作成権限を持つユーザーを取得します
+ *
+ * @param adminToken - 管理者のユーザートークン（xoxp-...）
+ * @param teamId - ワークスペースのチームID
+ * @returns 権限を持つユーザーのリスト
+ * @throws {Error} APIリクエストに失敗した場合
+ *
+ * @example
+ * ```typescript
+ * const users = await getAuthorizedUsersWithAdminApi(adminToken, teamId);
+ * console.log(users); // [{ id: "U123", name: "admin", ... }]
+ * ```
+ */
+export async function getAuthorizedUsersWithAdminApi(
+  adminToken: string,
+  teamId: string,
+): Promise<AuthorizedUser[]> {
+  console.log(t("logs.fetching_authorized_users", { teamId }));
+
+  const authorizedUsers: AuthorizedUser[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const params = new URLSearchParams({
+      team_id: teamId,
+      limit: "200",
+    });
+
+    if (cursor) {
+      params.append("cursor", cursor);
+    }
+
+    const response = await fetch(
+      `https://slack.com/api/admin.users.list?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${adminToken}`,
+          "Content-Type": "application/json; charset=utf-8",
+        },
+      },
+    );
+
+    const result: AdminUsersListResponse = await response.json();
+
+    console.log("admin.users.list response:", {
+      ok: result.ok,
+      error: result.error,
+      user_count: result.users?.length ?? 0,
+      has_next_cursor: !!result.response_metadata?.next_cursor,
+    });
+
+    if (!result.ok) {
+      throw new Error(
+        t("errors.fetch_authorized_users_failed", {
+          error: result.error ?? t("errors.unknown_error"),
+        }),
+      );
+    }
+
+    if (result.users) {
+      for (const user of result.users) {
+        // ボット、削除済み、ゲストユーザーを除外
+        if (user.is_bot || user.deleted || user.is_restricted || user.is_ultra_restricted) {
+          continue;
+        }
+
+        // 管理者またはオーナーのみを抽出
+        if (user.is_admin || user.is_owner || user.is_primary_owner) {
+          authorizedUsers.push({
+            id: user.id,
+            name: user.name ?? "",
+            real_name: user.real_name ?? "",
+            is_admin: user.is_admin ?? false,
+            is_owner: user.is_owner ?? false,
+            is_primary_owner: user.is_primary_owner ?? false,
+          });
+        }
+      }
+    }
+
+    cursor = result.response_metadata?.next_cursor;
+  } while (cursor);
+
+  console.log(
+    t("logs.authorized_users_fetched", { count: authorizedUsers.length }),
+  );
+
+  return authorizedUsers;
+}
+
+export default SlackFunction(
+  GetAuthorizedUsersDefinition,
+  async ({ inputs, client, env }) => {
+    try {
+      // バリデーション
+      const channelId = channelIdSchema.parse(inputs.channel_id);
+
+      // 環境変数から Admin User Token を取得
+      const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+
+      if (!adminToken) {
+        throw new Error(t("errors.missing_admin_token"));
+      }
+
+      // ワークスペースの team_id を取得
+      const teamId = await getWorkspaceTeamId(client, channelId);
+
+      // Admin API で権限を持つユーザーを取得
+      const authorizedUsers = await getAuthorizedUsersWithAdminApi(
+        adminToken,
+        teamId,
+      );
+
+      // ユーザーIDのリストを作成
+      const userIds = authorizedUsers.map((user) => user.id);
+
+      return {
+        outputs: {
+          authorized_users: authorizedUsers,
+          user_ids: userIds,
+          count: authorizedUsers.length,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      console.error("Function error:", message);
+      return { error: message };
+    }
+  },
+);

--- a/functions/get_authorized_users/test.ts
+++ b/functions/get_authorized_users/test.ts
@@ -1,8 +1,5 @@
 import { assertEquals, assertRejects } from "std/testing/asserts.ts";
-import {
-  AuthorizedUser,
-  getAuthorizedUsersWithAdminApi,
-} from "./mod.ts";
+import { AuthorizedUser, getAuthorizedUsersWithAdminApi } from "./mod.ts";
 import { initI18n } from "../../lib/i18n/mod.ts";
 
 // テスト前にi18nを初期化
@@ -386,7 +383,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "getAuthorizedUsersWithAdminApi: 権限ユーザーがいない場合は空配列を返す",
+  name:
+    "getAuthorizedUsersWithAdminApi: 権限ユーザーがいない場合は空配列を返す",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {

--- a/functions/get_authorized_users/test.ts
+++ b/functions/get_authorized_users/test.ts
@@ -1,0 +1,496 @@
+import { assertEquals, assertRejects } from "std/testing/asserts.ts";
+import {
+  AuthorizedUser,
+  getAuthorizedUsersWithAdminApi,
+} from "./mod.ts";
+import { initI18n } from "../../lib/i18n/mod.ts";
+
+// テスト前にi18nを初期化
+await initI18n();
+
+// fetch のモック用グローバル変数
+const originalFetch = globalThis.fetch;
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+/**
+ * getAuthorizedUsersWithAdminApi のテスト
+ * 実際のAPIは呼び出さず、fetch をモックしてテスト
+ */
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: 正常に管理者/オーナーを取得できる",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [
+              {
+                id: "U001",
+                name: "admin_user",
+                real_name: "Admin User",
+                is_admin: true,
+                is_owner: false,
+                is_primary_owner: false,
+                is_bot: false,
+                deleted: false,
+              },
+              {
+                id: "U002",
+                name: "owner_user",
+                real_name: "Owner User",
+                is_admin: false,
+                is_owner: true,
+                is_primary_owner: false,
+                is_bot: false,
+                deleted: false,
+              },
+              {
+                id: "U003",
+                name: "regular_user",
+                real_name: "Regular User",
+                is_admin: false,
+                is_owner: false,
+                is_primary_owner: false,
+                is_bot: false,
+                deleted: false,
+              },
+            ],
+            response_metadata: {},
+          }),
+      } as Response);
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      // 管理者とオーナーのみが返される（2人）
+      assertEquals(result.length, 2);
+      assertEquals(result[0].id, "U001");
+      assertEquals(result[0].is_admin, true);
+      assertEquals(result[1].id, "U002");
+      assertEquals(result[1].is_owner, true);
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: プライマリオーナーも取得できる",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [
+              {
+                id: "U001",
+                name: "primary_owner",
+                real_name: "Primary Owner",
+                is_admin: false,
+                is_owner: false,
+                is_primary_owner: true,
+                is_bot: false,
+                deleted: false,
+              },
+            ],
+            response_metadata: {},
+          }),
+      } as Response);
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      assertEquals(result.length, 1);
+      assertEquals(result[0].id, "U001");
+      assertEquals(result[0].is_primary_owner, true);
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: ボットユーザーを除外する",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [
+              {
+                id: "U001",
+                name: "admin_user",
+                real_name: "Admin User",
+                is_admin: true,
+                is_owner: false,
+                is_bot: false,
+                deleted: false,
+              },
+              {
+                id: "B001",
+                name: "admin_bot",
+                real_name: "Admin Bot",
+                is_admin: true,
+                is_owner: false,
+                is_bot: true,
+                deleted: false,
+              },
+            ],
+            response_metadata: {},
+          }),
+      } as Response);
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      // ボットは除外されるので1人のみ
+      assertEquals(result.length, 1);
+      assertEquals(result[0].id, "U001");
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: 削除済みユーザーを除外する",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [
+              {
+                id: "U001",
+                name: "active_admin",
+                real_name: "Active Admin",
+                is_admin: true,
+                is_owner: false,
+                is_bot: false,
+                deleted: false,
+              },
+              {
+                id: "U002",
+                name: "deleted_admin",
+                real_name: "Deleted Admin",
+                is_admin: true,
+                is_owner: false,
+                is_bot: false,
+                deleted: true,
+              },
+            ],
+            response_metadata: {},
+          }),
+      } as Response);
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      // 削除済みユーザーは除外されるので1人のみ
+      assertEquals(result.length, 1);
+      assertEquals(result[0].id, "U001");
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: ゲストユーザーを除外する",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [
+              {
+                id: "U001",
+                name: "admin_user",
+                real_name: "Admin User",
+                is_admin: true,
+                is_owner: false,
+                is_bot: false,
+                deleted: false,
+                is_restricted: false,
+                is_ultra_restricted: false,
+              },
+              {
+                id: "U002",
+                name: "guest_admin",
+                real_name: "Guest Admin",
+                is_admin: true,
+                is_owner: false,
+                is_bot: false,
+                deleted: false,
+                is_restricted: true,
+                is_ultra_restricted: false,
+              },
+              {
+                id: "U003",
+                name: "single_channel_guest",
+                real_name: "Single Channel Guest",
+                is_admin: true,
+                is_owner: false,
+                is_bot: false,
+                deleted: false,
+                is_restricted: false,
+                is_ultra_restricted: true,
+              },
+            ],
+            response_metadata: {},
+          }),
+      } as Response);
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      // ゲストは除外されるので1人のみ
+      assertEquals(result.length, 1);
+      assertEquals(result[0].id, "U001");
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: ページネーションを処理できる",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    let callCount = 0;
+
+    globalThis.fetch = () => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              users: [
+                {
+                  id: "U001",
+                  name: "admin1",
+                  real_name: "Admin 1",
+                  is_admin: true,
+                  is_owner: false,
+                  is_bot: false,
+                  deleted: false,
+                },
+              ],
+              response_metadata: {
+                next_cursor: "cursor123",
+              },
+            }),
+        } as Response);
+      } else {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              users: [
+                {
+                  id: "U002",
+                  name: "admin2",
+                  real_name: "Admin 2",
+                  is_admin: true,
+                  is_owner: false,
+                  is_bot: false,
+                  deleted: false,
+                },
+              ],
+              response_metadata: {},
+            }),
+        } as Response);
+      }
+    };
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      // ページネーションで2回呼び出され、2人のユーザーを取得
+      assertEquals(callCount, 2);
+      assertEquals(result.length, 2);
+      assertEquals(result[0].id, "U001");
+      assertEquals(result[1].id, "U002");
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: APIエラー時に例外をスローする",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: false,
+            error: "invalid_auth",
+          }),
+      } as Response);
+
+    try {
+      await assertRejects(
+        () =>
+          getAuthorizedUsersWithAdminApi(
+            "xoxp-invalid-token",
+            "T12345678",
+          ),
+        Error,
+      );
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: 権限ユーザーがいない場合は空配列を返す",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [
+              {
+                id: "U001",
+                name: "regular_user",
+                real_name: "Regular User",
+                is_admin: false,
+                is_owner: false,
+                is_primary_owner: false,
+                is_bot: false,
+                deleted: false,
+              },
+            ],
+            response_metadata: {},
+          }),
+      } as Response);
+
+    try {
+      const result = await getAuthorizedUsersWithAdminApi(
+        "xoxp-test-token",
+        "T12345678",
+      );
+
+      assertEquals(result.length, 0);
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getAuthorizedUsersWithAdminApi: 正しいパラメータでAPIを呼び出す",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    let capturedUrl = "";
+    let capturedOptions: RequestInit | undefined;
+
+    globalThis.fetch = (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      capturedUrl = url.toString();
+      capturedOptions = options;
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            users: [],
+            response_metadata: {},
+          }),
+      } as Response);
+    };
+
+    try {
+      await getAuthorizedUsersWithAdminApi(
+        "xoxp-my-admin-token",
+        "T98765432",
+      );
+
+      // URL の検証（team_idとlimitがパラメータに含まれる）
+      assertEquals(
+        capturedUrl.includes("https://slack.com/api/admin.users.list"),
+        true,
+      );
+      assertEquals(capturedUrl.includes("team_id=T98765432"), true);
+      assertEquals(capturedUrl.includes("limit=200"), true);
+
+      // メソッドの検証
+      assertEquals(capturedOptions?.method, "GET");
+
+      // ヘッダーの検証
+      const headers = capturedOptions?.headers as Record<string, string>;
+      assertEquals(headers["Authorization"], "Bearer xoxp-my-admin-token");
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+/**
+ * AuthorizedUser 型のテスト
+ */
+Deno.test("AuthorizedUser: 型が正しく定義されている", () => {
+  const user: AuthorizedUser = {
+    id: "U12345678",
+    name: "test_user",
+    real_name: "Test User",
+    is_admin: true,
+    is_owner: false,
+    is_primary_owner: false,
+  };
+
+  assertEquals(user.id, "U12345678");
+  assertEquals(user.name, "test_user");
+  assertEquals(user.real_name, "Test User");
+  assertEquals(user.is_admin, true);
+  assertEquals(user.is_owner, false);
+  assertEquals(user.is_primary_owner, false);
+});

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -1,0 +1,759 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { z } from "zod";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+import {
+  nonEmptyStringSchema,
+  userIdSchema,
+} from "../../lib/validation/schemas.ts";
+
+// i18nを初期化
+await initI18n();
+
+/**
+ * 認可ユーザー情報の型定義
+ */
+interface AuthorizedUser {
+  id: string;
+  name: string;
+  real_name: string;
+  is_admin: boolean;
+  is_owner: boolean;
+  is_primary_owner: boolean;
+}
+
+/**
+ * プライベートチャンネル作成リクエストフォームを表示する関数の定義
+ *
+ * 権限を持つユーザーのみを承認者として選択できるカスタムモーダルを表示します。
+ */
+export const ShowPrivateChannelFormDefinition = DefineFunction({
+  callback_id: "show_private_channel_form",
+  title: "Show Private Channel Request Form",
+  description:
+    "Display a form for private channel creation with filtered approver list",
+  source_file: "functions/show_private_channel_form/mod.ts",
+  input_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "Interactivity context for opening the modal",
+      },
+      user_id: {
+        type: Schema.slack.types.user_id,
+        description: "User ID of the requester",
+      },
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description: "Channel where the request was made",
+      },
+      authorized_users: {
+        type: Schema.types.array,
+        items: {
+          type: Schema.types.object,
+          properties: {
+            id: { type: Schema.types.string },
+            name: { type: Schema.types.string },
+            real_name: { type: Schema.types.string },
+            is_admin: { type: Schema.types.boolean },
+            is_owner: { type: Schema.types.boolean },
+            is_primary_owner: { type: Schema.types.boolean },
+          },
+          required: ["id", "name", "real_name"],
+        },
+        description: "List of users authorized to approve requests",
+      },
+    },
+    required: ["interactivity", "user_id", "channel_id", "authorized_users"],
+  },
+  output_parameters: {
+    properties: {
+      approved: {
+        type: Schema.types.boolean,
+        description: "Whether the request was approved",
+      },
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description: "ID of the created channel (if approved)",
+      },
+      channel_name: {
+        type: Schema.types.string,
+        description: "Name of the created channel (if approved)",
+      },
+      reviewer_id: {
+        type: Schema.slack.types.user_id,
+        description: "ID of the user who reviewed the request",
+      },
+    },
+    required: ["approved", "reviewer_id"],
+  },
+});
+
+/**
+ * チャンネル名を正規化します
+ */
+export function normalizeChannelName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-_]/g, "")
+    .slice(0, 80);
+}
+
+/**
+ * Admin API を使用してプライベートチャンネルを作成します
+ */
+async function createPrivateChannelWithAdminApi(
+  adminToken: string,
+  channelName: string,
+  teamId: string,
+): Promise<{ ok: boolean; channel_id?: string; error?: string }> {
+  console.log(t("logs.creating_channel_admin_api", { name: channelName }));
+
+  const response = await fetch(
+    "https://slack.com/api/admin.conversations.create",
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${adminToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        name: channelName,
+        is_private: true,
+        team_id: teamId,
+      }),
+    },
+  );
+
+  const result = await response.json();
+
+  if (!result.ok) {
+    return { ok: false, error: result.error ?? t("errors.unknown_error") };
+  }
+
+  return { ok: true, channel_id: result.channel_id };
+}
+
+/**
+ * ワークスペースの team_id を取得します
+ */
+async function getWorkspaceTeamId(
+  // deno-lint-ignore no-explicit-any
+  client: any,
+  channelId: string,
+): Promise<string> {
+  const response = await client.conversations.info({ channel: channelId });
+
+  if (!response.ok || !response.channel) {
+    throw new Error(
+      t("errors.channel_info_failed", {
+        error: response.error ?? t("errors.unknown_error"),
+      }),
+    );
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const teamId = (response.channel as any).context_team_id as string;
+
+  if (!teamId) {
+    throw new Error(t("errors.missing_team_id"));
+  }
+
+  return teamId;
+}
+
+/**
+ * 承認者選択のオプションを生成します
+ */
+function buildApproverOptions(authorizedUsers: AuthorizedUser[]) {
+  return authorizedUsers.map((user) => {
+    // 役割を表示用に追加
+    const roles: string[] = [];
+    if (user.is_primary_owner) roles.push("Primary Owner");
+    else if (user.is_owner) roles.push("Owner");
+    if (user.is_admin) roles.push("Admin");
+
+    const roleText = roles.length > 0 ? ` (${roles.join(", ")})` : "";
+    const displayName = user.real_name || user.name;
+
+    return {
+      text: {
+        type: "plain_text" as const,
+        text: `${displayName}${roleText}`.slice(0, 75),
+        emoji: true,
+      },
+      value: user.id,
+    };
+  });
+}
+
+export default SlackFunction(
+  ShowPrivateChannelFormDefinition,
+  async ({ inputs, client }) => {
+    try {
+      const authorizedUsers = inputs.authorized_users as AuthorizedUser[];
+      const channelId = inputs.channel_id as string;
+      const userId = inputs.user_id as string;
+
+      // 権限ユーザーがいない場合はエラー
+      if (!authorizedUsers || authorizedUsers.length === 0) {
+        throw new Error(t("errors.no_authorized_users"));
+      }
+
+      // 承認者選択のオプションを生成
+      const approverOptions = buildApproverOptions(authorizedUsers);
+
+      console.log(
+        t("logs.opening_form_with_authorized_users", {
+          count: authorizedUsers.length,
+        }),
+      );
+
+      // カスタムモーダルを開く
+      const viewResult = await client.views.open({
+        interactivity_pointer: inputs.interactivity.interactivity_pointer,
+        view: {
+          type: "modal",
+          callback_id: "private_channel_request_modal",
+          title: {
+            type: "plain_text",
+            text: t("form.title"),
+            emoji: true,
+          },
+          submit: {
+            type: "plain_text",
+            text: t("form.submit_button"),
+            emoji: true,
+          },
+          close: {
+            type: "plain_text",
+            text: t("form.cancel_button"),
+            emoji: true,
+          },
+          private_metadata: JSON.stringify({
+            channel_id: channelId,
+            user_id: userId,
+          }),
+          blocks: [
+            {
+              type: "input",
+              block_id: "channel_name_block",
+              element: {
+                type: "plain_text_input",
+                action_id: "channel_name_input",
+                placeholder: {
+                  type: "plain_text",
+                  text: t("form.channel_name_placeholder"),
+                },
+              },
+              label: {
+                type: "plain_text",
+                text: t("form.channel_name_label"),
+                emoji: true,
+              },
+              hint: {
+                type: "plain_text",
+                text: t("form.channel_name_hint"),
+              },
+            },
+            {
+              type: "input",
+              block_id: "approver_block",
+              element: {
+                type: "static_select",
+                action_id: "approver_select",
+                placeholder: {
+                  type: "plain_text",
+                  text: t("form.approver_placeholder"),
+                },
+                options: approverOptions,
+              },
+              label: {
+                type: "plain_text",
+                text: t("form.approver_label"),
+                emoji: true,
+              },
+              hint: {
+                type: "plain_text",
+                text: t("form.approver_hint"),
+              },
+            },
+            {
+              type: "input",
+              block_id: "description_block",
+              optional: true,
+              element: {
+                type: "plain_text_input",
+                action_id: "description_input",
+                multiline: true,
+                placeholder: {
+                  type: "plain_text",
+                  text: t("form.description_placeholder"),
+                },
+              },
+              label: {
+                type: "plain_text",
+                text: t("form.description_label"),
+                emoji: true,
+              },
+            },
+            {
+              type: "input",
+              block_id: "initial_members_block",
+              optional: true,
+              element: {
+                type: "multi_users_select",
+                action_id: "initial_members_select",
+                placeholder: {
+                  type: "plain_text",
+                  text: t("form.initial_members_placeholder"),
+                },
+              },
+              label: {
+                type: "plain_text",
+                text: t("form.initial_members_label"),
+                emoji: true,
+              },
+            },
+          ],
+        },
+      });
+
+      if (!viewResult.ok) {
+        throw new Error(
+          t("errors.modal_open_failed", {
+            error: viewResult.error ?? t("errors.unknown_error"),
+          }),
+        );
+      }
+
+      console.log(t("logs.modal_opened"));
+
+      // 関数を未完了状態で返す（モーダル送信を待つ）
+      return { completed: false };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      console.error("Function error:", message);
+      return { error: message };
+    }
+  },
+)
+  // モーダル送信時のハンドラー
+  .addViewSubmissionHandler(
+    ["private_channel_request_modal"],
+    async ({ view, body, client }) => {
+      console.log("=== Modal submitted ===");
+
+      // private_metadataから情報を取得
+      const metadata = JSON.parse(view.private_metadata || "{}");
+      const approvalChannelId = metadata.channel_id;
+      const requesterId = metadata.user_id;
+
+      // フォーム入力値を取得
+      const values = view.state.values;
+      const channelName =
+        values.channel_name_block?.channel_name_input?.value || "";
+      const approverId =
+        values.approver_block?.approver_select?.selected_option?.value || "";
+      const description =
+        values.description_block?.description_input?.value || "";
+      const initialMembers =
+        values.initial_members_block?.initial_members_select?.selected_users ||
+        [];
+
+      console.log("Form values:", {
+        channelName,
+        approverId,
+        description,
+        initialMembersCount: initialMembers.length,
+      });
+
+      try {
+        // バリデーション
+        const validatedChannelName = nonEmptyStringSchema.parse(channelName);
+        const validatedApproverId = userIdSchema.parse(approverId);
+        const normalizedName = normalizeChannelName(validatedChannelName);
+
+        if (normalizedName.length === 0) {
+          throw new Error(
+            t("errors.invalid_channel_name", { name: channelName }),
+          );
+        }
+
+        // 初期メンバーのバリデーション
+        if (initialMembers.length > 0) {
+          const membersSchema = z.array(userIdSchema);
+          membersSchema.parse(initialMembers);
+        }
+
+        // リクエスト情報をメッセージに含める
+        const membersText = initialMembers.length > 0
+          ? initialMembers.map((m: string) => `<@${m}>`).join(", ")
+          : t("messages.no_initial_members");
+
+        const descriptionText = description || t("messages.no_description");
+
+        // 承認リクエストメッセージを送信
+        await client.chat.postMessage({
+          channel: approvalChannelId,
+          text: t("messages.approval_request_title", { channel: normalizedName }),
+          blocks: [
+            {
+              type: "header",
+              text: {
+                type: "plain_text",
+                text: t("messages.approval_request_header"),
+                emoji: true,
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: t("messages.approval_request_details", {
+                  requester: requesterId,
+                  channel: normalizedName,
+                  description: descriptionText,
+                  members: membersText,
+                }),
+              },
+            },
+            {
+              type: "actions",
+              block_id: "approval_actions",
+              elements: [
+                {
+                  type: "button",
+                  text: {
+                    type: "plain_text",
+                    text: t("messages.approve_button"),
+                    emoji: true,
+                  },
+                  action_id: "approve_filtered_channel_request",
+                  style: "primary",
+                  value: JSON.stringify({
+                    channel_name: normalizedName,
+                    requester_id: requesterId,
+                    approver_id: validatedApproverId,
+                    description: description || "",
+                    initial_members: initialMembers,
+                    approval_channel_id: approvalChannelId,
+                  }),
+                },
+                {
+                  type: "button",
+                  text: {
+                    type: "plain_text",
+                    text: t("messages.deny_button"),
+                    emoji: true,
+                  },
+                  action_id: "deny_filtered_channel_request",
+                  style: "danger",
+                  value: JSON.stringify({
+                    channel_name: normalizedName,
+                    requester_id: requesterId,
+                    approver_id: validatedApproverId,
+                  }),
+                },
+              ],
+            },
+            {
+              type: "context",
+              elements: [
+                {
+                  type: "mrkdwn",
+                  text: t("messages.approval_context", {
+                    approver: validatedApproverId,
+                  }),
+                },
+              ],
+            },
+          ],
+        });
+
+        console.log(t("logs.approval_request_sent"));
+
+        // モーダルを閉じる（空のレスポンスを返す）
+        return;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : `${error}`;
+        console.error("View submission error:", message);
+
+        // エラー時はモーダルにエラーを表示
+        return {
+          response_action: "errors" as const,
+          errors: {
+            channel_name_block: message,
+          },
+        };
+      }
+    },
+  )
+  // 承認ボタンのハンドラー
+  .addBlockActionsHandler(
+    ["approve_filtered_channel_request"],
+    async ({ action, body, client, env }) => {
+      console.log("=== Filtered approval button clicked ===");
+
+      const reviewerId = body.user.id;
+      const messageTs = body.message?.ts;
+      // deno-lint-ignore no-explicit-any
+      const channelId = (body as any).channel?.id;
+
+      // ボタンの value から情報を取得
+      const requestData = JSON.parse(action.value || "{}");
+      const channelName = requestData.channel_name;
+      const requesterId = requestData.requester_id;
+      const approverId = requestData.approver_id;
+      const description = requestData.description;
+      const initialMembers = requestData.initial_members || [];
+      const approvalChannelId = requestData.approval_channel_id;
+
+      // 承認者チェック
+      if (approverId && reviewerId !== approverId) {
+        console.log(
+          `Unauthorized approval attempt: ${reviewerId} is not ${approverId}`,
+        );
+        await client.chat.postEphemeral({
+          channel: approvalChannelId,
+          user: reviewerId,
+          text: t("errors.not_authorized_approver", { approver: approverId }),
+        });
+        return;
+      }
+
+      try {
+        const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+
+        if (!adminToken) {
+          throw new Error(t("errors.missing_admin_token"));
+        }
+
+        const teamId = await getWorkspaceTeamId(client, approvalChannelId);
+
+        console.log(
+          t("logs.creating_channel_after_approval", { name: channelName }),
+        );
+
+        const createResult = await createPrivateChannelWithAdminApi(
+          adminToken,
+          channelName,
+          teamId,
+        );
+
+        if (!createResult.ok) {
+          throw new Error(
+            t("errors.channel_create_failed", {
+              error: createResult.error || t("errors.unknown_error"),
+            }),
+          );
+        }
+
+        const newChannelId = createResult.channel_id!;
+
+        console.log("=== Private channel created successfully ===");
+        console.log("Channel ID:", newChannelId);
+
+        // トピック設定
+        if (description && description.trim().length > 0) {
+          try {
+            await client.conversations.setTopic({
+              channel: newChannelId,
+              topic: description,
+            });
+          } catch (topicError) {
+            console.error("Failed to set topic:", topicError);
+          }
+        }
+
+        // メンバー招待（Admin API使用）
+        const inviteWithAdminApi = async (
+          userIds: string[],
+        ): Promise<{ ok: boolean; error?: string }> => {
+          if (userIds.length === 0) return { ok: true };
+          const response = await fetch(
+            "https://slack.com/api/admin.conversations.invite",
+            {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${adminToken}`,
+                "Content-Type": "application/json; charset=utf-8",
+              },
+              body: JSON.stringify({
+                channel_id: newChannelId,
+                user_ids: userIds.join(","),
+              }),
+            },
+          );
+          return await response.json();
+        };
+
+        const allMembersToInvite = [requesterId];
+        for (const member of initialMembers) {
+          if (!allMembersToInvite.includes(member)) {
+            allMembersToInvite.push(member);
+          }
+        }
+
+        console.log("Inviting members:", allMembersToInvite);
+        try {
+          const inviteResult = await inviteWithAdminApi(allMembersToInvite);
+          if (!inviteResult.ok) {
+            console.error("Failed to invite members:", inviteResult.error);
+          }
+        } catch (inviteError) {
+          console.error("Failed to invite members:", inviteError);
+        }
+
+        // メッセージを更新
+        if (messageTs && channelId) {
+          await client.chat.update({
+            channel: channelId,
+            ts: messageTs,
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: t("messages.channel_approved", {
+                    channel: channelName,
+                    channel_id: newChannelId,
+                    reviewer: reviewerId,
+                    requester: requesterId,
+                  }),
+                },
+              },
+              {
+                type: "context",
+                elements: [
+                  {
+                    type: "mrkdwn",
+                    text: `✅ ${t("messages.approved_at", { time: new Date().toISOString() })}`,
+                  },
+                ],
+              },
+            ],
+          });
+        }
+
+        // 関数を完了
+        await client.functions.completeSuccess({
+          function_execution_id: body.function_data.execution_id,
+          outputs: {
+            approved: true,
+            channel_id: newChannelId,
+            channel_name: channelName,
+            reviewer_id: reviewerId,
+          },
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error
+          ? error.message
+          : `${error}`;
+        console.error("Approval handler error:", errorMessage);
+
+        if (messageTs && channelId) {
+          await client.chat.update({
+            channel: channelId,
+            ts: messageTs,
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: t("messages.channel_creation_failed", {
+                    channel: channelName,
+                    error: errorMessage,
+                  }),
+                },
+              },
+            ],
+          });
+        }
+
+        await client.functions.completeError({
+          function_execution_id: body.function_data.execution_id,
+          error: errorMessage,
+        });
+      }
+    },
+  )
+  // 拒否ボタンのハンドラー
+  .addBlockActionsHandler(
+    ["deny_filtered_channel_request"],
+    async ({ action, body, client }) => {
+      console.log("Deny button clicked");
+
+      const reviewerId = body.user.id;
+      const messageTs = body.message?.ts;
+      // deno-lint-ignore no-explicit-any
+      const channelId = (body as any).channel?.id;
+
+      const requestData = JSON.parse(action.value || "{}");
+      const channelName = requestData.channel_name;
+      const requesterId = requestData.requester_id;
+      const approverId = requestData.approver_id;
+
+      if (approverId && reviewerId !== approverId) {
+        await client.chat.postEphemeral({
+          channel: channelId,
+          user: reviewerId,
+          text: t("errors.not_authorized_approver", { approver: approverId }),
+        });
+        return;
+      }
+
+      if (messageTs && channelId) {
+        await client.chat.update({
+          channel: channelId,
+          ts: messageTs,
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: t("messages.channel_denied", {
+                  channel: channelName,
+                  reviewer: reviewerId,
+                  requester: requesterId,
+                }),
+              },
+            },
+            {
+              type: "context",
+              elements: [
+                {
+                  type: "mrkdwn",
+                  text: `❌ ${t("messages.denied_at", { time: new Date().toISOString() })}`,
+                },
+              ],
+            },
+          ],
+        });
+      }
+
+      await client.functions.completeSuccess({
+        function_execution_id: body.function_data.execution_id,
+        outputs: {
+          approved: false,
+          reviewer_id: reviewerId,
+        },
+      });
+    },
+  )
+  // モーダルクローズ時のハンドラー
+  .addViewClosedHandler(
+    ["private_channel_request_modal"],
+    async ({ body, client }) => {
+      console.log("Modal closed by user");
+
+      // ユーザーがモーダルを閉じた場合、関数をエラーなしで完了
+      await client.functions.completeSuccess({
+        function_execution_id: body.function_data.execution_id,
+        outputs: {
+          approved: false,
+          reviewer_id: body.user.id,
+        },
+      });
+    },
+  );

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -5,6 +5,7 @@ import {
   nonEmptyStringSchema,
   userIdSchema,
 } from "../../lib/validation/schemas.ts";
+import { AuthorizedUserType } from "../../lib/types/authorized_user.ts";
 
 // i18nを初期化
 await initI18n();
@@ -49,16 +50,7 @@ export const ShowPrivateChannelFormDefinition = DefineFunction({
       authorized_users: {
         type: Schema.types.array,
         items: {
-          type: Schema.types.object,
-          properties: {
-            id: { type: Schema.types.string },
-            name: { type: Schema.types.string },
-            real_name: { type: Schema.types.string },
-            is_admin: { type: Schema.types.boolean },
-            is_owner: { type: Schema.types.boolean },
-            is_primary_owner: { type: Schema.types.boolean },
-          },
-          required: ["id", "name", "real_name"],
+          type: AuthorizedUserType,
         },
         description: "List of users authorized to approve requests",
       },
@@ -341,7 +333,7 @@ export default SlackFunction(
   // モーダル送信時のハンドラー
   .addViewSubmissionHandler(
     ["private_channel_request_modal"],
-    async ({ view, body, client }) => {
+    async ({ view, body: _body, client }) => {
       console.log("=== Modal submitted ===");
 
       // private_metadataから情報を取得
@@ -355,8 +347,8 @@ export default SlackFunction(
         values.channel_name_block?.channel_name_input?.value || "";
       const approverId =
         values.approver_block?.approver_select?.selected_option?.value || "";
-      const description =
-        values.description_block?.description_input?.value || "";
+      const description = values.description_block?.description_input?.value ||
+        "";
       const initialMembers =
         values.initial_members_block?.initial_members_select?.selected_users ||
         [];
@@ -396,7 +388,9 @@ export default SlackFunction(
         // 承認リクエストメッセージを送信
         await client.chat.postMessage({
           channel: approvalChannelId,
-          text: t("messages.approval_request_title", { channel: normalizedName }),
+          text: t("messages.approval_request_title", {
+            channel: normalizedName,
+          }),
           blocks: [
             {
               type: "header",
@@ -628,7 +622,11 @@ export default SlackFunction(
                 elements: [
                   {
                     type: "mrkdwn",
-                    text: `✅ ${t("messages.approved_at", { time: new Date().toISOString() })}`,
+                    text: `✅ ${
+                      t("messages.approved_at", {
+                        time: new Date().toISOString(),
+                      })
+                    }`,
                   },
                 ],
               },
@@ -724,7 +722,9 @@ export default SlackFunction(
               elements: [
                 {
                   type: "mrkdwn",
-                  text: `❌ ${t("messages.denied_at", { time: new Date().toISOString() })}`,
+                  text: `❌ ${
+                    t("messages.denied_at", { time: new Date().toISOString() })
+                  }`,
                 },
               ],
             },

--- a/functions/show_private_channel_form/test.ts
+++ b/functions/show_private_channel_form/test.ts
@@ -1,0 +1,233 @@
+import { assertEquals } from "std/testing/asserts.ts";
+import { normalizeChannelName } from "./mod.ts";
+import { initI18n } from "../../lib/i18n/mod.ts";
+
+// テスト前にi18nを初期化
+await initI18n();
+
+/**
+ * normalizeChannelName のテスト
+ */
+Deno.test("normalizeChannelName: 正常にチャンネル名を正規化できる", () => {
+  assertEquals(normalizeChannelName("Project Alpha"), "project-alpha");
+  assertEquals(normalizeChannelName("Test Channel"), "test-channel");
+  assertEquals(normalizeChannelName("my_channel"), "my_channel");
+});
+
+Deno.test("normalizeChannelName: 特殊文字を除去する", () => {
+  assertEquals(normalizeChannelName("Test@#Channel!"), "testchannel");
+  assertEquals(normalizeChannelName("Project $%^ Beta"), "project--beta");
+});
+
+Deno.test("normalizeChannelName: 80文字以内に制限する", () => {
+  const longName = "a".repeat(100);
+  const result = normalizeChannelName(longName);
+  assertEquals(result.length, 80);
+});
+
+Deno.test("normalizeChannelName: 空文字を返す（無効な文字のみの場合）", () => {
+  assertEquals(normalizeChannelName("@#$%"), "");
+});
+
+/**
+ * buildApproverOptions の動作確認テスト
+ * （関数はエクスポートされていないため、結果の形式を間接的にテスト）
+ */
+
+Deno.test("AuthorizedUser型: 必須フィールドが正しく定義されている", () => {
+  const user = {
+    id: "U12345678",
+    name: "test_user",
+    real_name: "Test User",
+    is_admin: true,
+    is_owner: false,
+    is_primary_owner: false,
+  };
+
+  assertEquals(user.id, "U12345678");
+  assertEquals(user.name, "test_user");
+  assertEquals(user.real_name, "Test User");
+  assertEquals(user.is_admin, true);
+  assertEquals(user.is_owner, false);
+});
+
+Deno.test("AuthorizedUser型: オーナーフラグが正しく設定される", () => {
+  const owner = {
+    id: "U87654321",
+    name: "owner_user",
+    real_name: "Owner User",
+    is_admin: false,
+    is_owner: true,
+    is_primary_owner: false,
+  };
+
+  assertEquals(owner.is_owner, true);
+  assertEquals(owner.is_admin, false);
+});
+
+Deno.test("AuthorizedUser型: プライマリオーナーフラグが正しく設定される", () => {
+  const primaryOwner = {
+    id: "U11111111",
+    name: "primary_owner",
+    real_name: "Primary Owner",
+    is_admin: false,
+    is_owner: false,
+    is_primary_owner: true,
+  };
+
+  assertEquals(primaryOwner.is_primary_owner, true);
+});
+
+/**
+ * モーダルのprivate_metadata JSONパース/シリアライズのテスト
+ */
+Deno.test("private_metadata: 正しくシリアライズ/デシリアライズできる", () => {
+  const metadata = {
+    channel_id: "C12345678",
+    user_id: "U87654321",
+  };
+
+  const serialized = JSON.stringify(metadata);
+  const deserialized = JSON.parse(serialized);
+
+  assertEquals(deserialized.channel_id, "C12345678");
+  assertEquals(deserialized.user_id, "U87654321");
+});
+
+Deno.test("private_metadata: 空のメタデータを処理できる", () => {
+  const emptyMetadata = "{}";
+  const parsed = JSON.parse(emptyMetadata);
+
+  assertEquals(parsed.channel_id, undefined);
+  assertEquals(parsed.user_id, undefined);
+});
+
+/**
+ * ボタンのvalue JSONパース/シリアライズのテスト
+ */
+Deno.test("button value: リクエストデータを正しくシリアライズできる", () => {
+  const requestData = {
+    channel_name: "test-channel",
+    requester_id: "U12345678",
+    approver_id: "U87654321",
+    description: "Test description",
+    initial_members: ["U11111111", "U22222222"],
+    approval_channel_id: "C99999999",
+  };
+
+  const serialized = JSON.stringify(requestData);
+  const deserialized = JSON.parse(serialized);
+
+  assertEquals(deserialized.channel_name, "test-channel");
+  assertEquals(deserialized.requester_id, "U12345678");
+  assertEquals(deserialized.approver_id, "U87654321");
+  assertEquals(deserialized.description, "Test description");
+  assertEquals(deserialized.initial_members.length, 2);
+  assertEquals(deserialized.approval_channel_id, "C99999999");
+});
+
+Deno.test("button value: 空の初期メンバーを処理できる", () => {
+  const requestData = {
+    channel_name: "test-channel",
+    requester_id: "U12345678",
+    approver_id: "U87654321",
+    description: "",
+    initial_members: [],
+    approval_channel_id: "C99999999",
+  };
+
+  const serialized = JSON.stringify(requestData);
+  const deserialized = JSON.parse(serialized);
+
+  assertEquals(deserialized.initial_members.length, 0);
+  assertEquals(deserialized.description, "");
+});
+
+/**
+ * 承認者オプションの表示テスト
+ */
+Deno.test("approver option: Admin表示が正しい形式", () => {
+  const user = {
+    id: "U12345678",
+    name: "admin_user",
+    real_name: "Admin User",
+    is_admin: true,
+    is_owner: false,
+    is_primary_owner: false,
+  };
+
+  const roles: string[] = [];
+  if (user.is_primary_owner) roles.push("Primary Owner");
+  else if (user.is_owner) roles.push("Owner");
+  if (user.is_admin) roles.push("Admin");
+
+  const roleText = roles.length > 0 ? ` (${roles.join(", ")})` : "";
+  const displayName = user.real_name || user.name;
+  const optionText = `${displayName}${roleText}`;
+
+  assertEquals(optionText, "Admin User (Admin)");
+});
+
+Deno.test("approver option: Owner + Admin表示が正しい形式", () => {
+  const user = {
+    id: "U12345678",
+    name: "owner_admin",
+    real_name: "Owner Admin User",
+    is_admin: true,
+    is_owner: true,
+    is_primary_owner: false,
+  };
+
+  const roles: string[] = [];
+  if (user.is_primary_owner) roles.push("Primary Owner");
+  else if (user.is_owner) roles.push("Owner");
+  if (user.is_admin) roles.push("Admin");
+
+  const roleText = roles.length > 0 ? ` (${roles.join(", ")})` : "";
+  const displayName = user.real_name || user.name;
+  const optionText = `${displayName}${roleText}`;
+
+  assertEquals(optionText, "Owner Admin User (Owner, Admin)");
+});
+
+Deno.test("approver option: Primary Owner表示が正しい形式", () => {
+  const user = {
+    id: "U12345678",
+    name: "primary_owner",
+    real_name: "Primary Owner User",
+    is_admin: true,
+    is_owner: false,
+    is_primary_owner: true,
+  };
+
+  const roles: string[] = [];
+  if (user.is_primary_owner) roles.push("Primary Owner");
+  else if (user.is_owner) roles.push("Owner");
+  if (user.is_admin) roles.push("Admin");
+
+  const roleText = roles.length > 0 ? ` (${roles.join(", ")})` : "";
+  const displayName = user.real_name || user.name;
+  const optionText = `${displayName}${roleText}`;
+
+  assertEquals(optionText, "Primary Owner User (Primary Owner, Admin)");
+});
+
+Deno.test("approver option: 75文字以内に制限される", () => {
+  const longName = "A".repeat(80);
+  const user = {
+    id: "U12345678",
+    name: "long_name_user",
+    real_name: longName,
+    is_admin: true,
+    is_owner: false,
+    is_primary_owner: false,
+  };
+
+  const roles: string[] = [];
+  if (user.is_admin) roles.push("Admin");
+  const roleText = ` (${roles.join(", ")})`;
+  const displayName = user.real_name;
+  const optionText = `${displayName}${roleText}`.slice(0, 75);
+
+  assertEquals(optionText.length, 75);
+});

--- a/lib/i18n/mod.ts
+++ b/lib/i18n/mod.ts
@@ -42,6 +42,11 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       missing_notification_channel: "Notification channel ID is required",
       missing_admin_token:
         "Admin user token (SLACK_ADMIN_USER_TOKEN) is not configured",
+      fetch_authorized_users_failed:
+        "Failed to fetch authorized users: {error}",
+      no_authorized_users:
+        "No authorized users found. Please ensure there are admins or owners in the workspace.",
+      modal_open_failed: "Failed to open the form: {error}",
       not_authorized_approver:
         "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
       validation: {
@@ -80,6 +85,23 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       approved_at: "Approved at {time}",
       denied_at: "Denied at {time}",
     },
+    form: {
+      title: "Request Private Channel",
+      submit_button: "Request",
+      cancel_button: "Cancel",
+      channel_name_label: "Channel Name",
+      channel_name_placeholder: "project-alpha",
+      channel_name_hint:
+        "Name of the private channel (without #). Will be converted to lowercase.",
+      approver_label: "Approver",
+      approver_placeholder: "Select an approver",
+      approver_hint:
+        "Only admins and owners can approve private channel creation.",
+      description_label: "Description",
+      description_placeholder: "What is this channel for?",
+      initial_members_label: "Initial Members",
+      initial_members_placeholder: "Select members to invite",
+    },
     logs: {
       starting: "Starting workflow...",
       completed: "Workflow completed",
@@ -97,6 +119,14 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       creating_channel_after_approval:
         "Creating channel '{name}' after approval",
       members_invited: "{count} members invited to the channel",
+      fetching_authorized_users: "Fetching authorized users for team: {teamId}",
+      authorized_users_fetched:
+        "Found {count} authorized users (admins/owners)",
+      opening_form_with_authorized_users:
+        "Opening form with {count} authorized users",
+      modal_opened: "Modal opened successfully",
+      max_page_limit_reached:
+        "Maximum page limit ({limit}) reached, stopping pagination",
     },
   },
   ja: {
@@ -123,6 +153,11 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       missing_notification_channel: "通知チャンネルIDが必要です",
       missing_admin_token:
         "管理者ユーザートークン（SLACK_ADMIN_USER_TOKEN）が設定されていません",
+      fetch_authorized_users_failed:
+        "認可ユーザーの取得に失敗しました: {error}",
+      no_authorized_users:
+        "認可ユーザーが見つかりません。ワークスペースに管理者またはオーナーがいることを確認してください。",
+      modal_open_failed: "フォームを開くことができませんでした: {error}",
       not_authorized_approver:
         "⚠️ このリクエストを承認する権限がありません。<@{approver}> のみが承認または拒否できます。",
       validation: {
@@ -162,6 +197,23 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       approved_at: "{time} に承認",
       denied_at: "{time} に拒否",
     },
+    form: {
+      title: "プライベートチャンネルをリクエスト",
+      submit_button: "リクエスト",
+      cancel_button: "キャンセル",
+      channel_name_label: "チャンネル名",
+      channel_name_placeholder: "project-alpha",
+      channel_name_hint:
+        "プライベートチャンネルの名前（#なし）。小文字に変換されます。",
+      approver_label: "承認者",
+      approver_placeholder: "承認者を選択してください",
+      approver_hint:
+        "管理者とオーナーのみがプライベートチャンネルの作成を承認できます。",
+      description_label: "説明",
+      description_placeholder: "このチャンネルの目的は？",
+      initial_members_label: "初期メンバー",
+      initial_members_placeholder: "招待するメンバーを選択してください",
+    },
     logs: {
       starting: "ワークフローを開始しています...",
       completed: "ワークフローが完了しました",
@@ -179,6 +231,14 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       approval_request_sent: "承認リクエストを送信しました",
       creating_channel_after_approval: "承認後にチャンネル '{name}' を作成中",
       members_invited: "{count} 人のメンバーを招待しました",
+      fetching_authorized_users: "チーム {teamId} の認可ユーザーを取得中です",
+      authorized_users_fetched:
+        "{count}人の認可ユーザー（管理者/オーナー）が見つかりました",
+      opening_form_with_authorized_users:
+        "{count}人の認可ユーザーでフォームを開いています",
+      modal_opened: "モーダルが正常に開きました",
+      max_page_limit_reached:
+        "最大ページ数（{limit}）に達したため、ページネーションを停止します",
     },
   },
 };

--- a/lib/i18n/mod.ts
+++ b/lib/i18n/mod.ts
@@ -52,7 +52,7 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       validation: {
         channel_id_empty: "Channel ID cannot be empty",
         channel_id_format:
-          "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
+          "Channel ID must start with 'C' (public), 'G' (private), or 'D' (DM) followed by uppercase alphanumeric characters",
         user_id_empty: "User ID cannot be empty",
         user_id_format:
           "User ID must start with 'U' or 'W' followed by uppercase alphanumeric characters",
@@ -163,7 +163,7 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       validation: {
         channel_id_empty: "チャンネルIDを空にすることはできません",
         channel_id_format:
-          "チャンネルIDは 'C' で始まり、大文字の英数字が続く必要があります",
+          "チャネルIDは'C'（パブリック）、'G'（プライベート）、または'D'（DM）で始まり、その後に大文字の英数字が続く必要があります",
         user_id_empty: "ユーザーIDを空にすることはできません",
         user_id_format:
           "ユーザーIDは 'U' または 'W' で始まり、大文字の英数字が続く必要があります",

--- a/lib/types/authorized_user.ts
+++ b/lib/types/authorized_user.ts
@@ -1,0 +1,39 @@
+import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
+
+/**
+ * AuthorizedUser カスタム型定義
+ *
+ * プライベートチャンネル作成権限を持つユーザーの情報を表すカスタム型です。
+ * Slack Manifestに登録して、関数のinput/output parametersで使用します。
+ */
+export const AuthorizedUserType = DefineType({
+  name: "authorized_user",
+  type: Schema.types.object,
+  properties: {
+    id: {
+      type: Schema.types.string,
+      description: "User ID",
+    },
+    name: {
+      type: Schema.types.string,
+      description: "Username",
+    },
+    real_name: {
+      type: Schema.types.string,
+      description: "Real name",
+    },
+    is_admin: {
+      type: Schema.types.boolean,
+      description: "Whether the user is an admin",
+    },
+    is_owner: {
+      type: Schema.types.boolean,
+      description: "Whether the user is an owner",
+    },
+    is_primary_owner: {
+      type: Schema.types.boolean,
+      description: "Whether the user is the primary owner",
+    },
+  },
+  required: ["id", "name", "real_name", "is_admin", "is_owner"],
+});

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -10,8 +10,11 @@ import { initI18n, t } from "../i18n/mod.ts";
 await initI18n();
 
 /**
- * i18n対応のSlackチャンネル ID スキーマを生成
- * 形式: C + 英数字大文字
+ * i18n対応のSlackチャンネル/会話 ID スキーマを生成
+ * 形式:
+ *   - C + 英数字大文字 (パブリックチャンネル)
+ *   - G + 英数字大文字 (プライベートチャンネル)
+ *   - D + 英数字大文字 (ダイレクトメッセージ)
  *
  * エラーメッセージは検証時に動的に評価されるため、
  * ロケール変更に対応します。
@@ -21,7 +24,9 @@ await initI18n();
  * @example
  * ```typescript
  * const schema = createChannelIdSchema();
- * const channelId = schema.parse("C12345678");
+ * const channelId = schema.parse("C12345678"); // パブリックチャンネル
+ * const privateChannelId = schema.parse("G12345678"); // プライベートチャンネル
+ * const dmId = schema.parse("D12345678"); // DM
  * ```
  */
 export function createChannelIdSchema() {
@@ -36,7 +41,8 @@ export function createChannelIdSchema() {
       });
       return;
     }
-    if (!/^C[A-Z0-9]+$/.test(val)) {
+    // C: パブリックチャンネル, G: プライベートチャンネル, D: DM
+    if (!/^[CGD][A-Z0-9]+$/.test(val)) {
       ctx.addIssue({
         code: z.ZodIssueCode.invalid_string,
         validation: "regex",

--- a/lib/validation/test.ts
+++ b/lib/validation/test.ts
@@ -24,11 +24,27 @@ await loadLocale("ja");
 
 const originalLocale = getLocale() as typeof SUPPORTED_LOCALES[number];
 
-Deno.test("channelIdSchema: 正常なチャンネルIDを検証", () => {
+Deno.test("channelIdSchema: 正常なパブリックチャンネルIDを検証", () => {
   const result = channelIdSchema.safeParse("C12345678");
   assertEquals(result.success, true);
   if (result.success) {
     assertEquals(result.data, "C12345678");
+  }
+});
+
+Deno.test("channelIdSchema: 正常なプライベートチャンネルIDを検証", () => {
+  const result = channelIdSchema.safeParse("G12345678");
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data, "G12345678");
+  }
+});
+
+Deno.test("channelIdSchema: 正常なDM IDを検証", () => {
+  const result = channelIdSchema.safeParse("D12345678");
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.data, "D12345678");
   }
 });
 
@@ -37,7 +53,8 @@ Deno.test("channelIdSchema: 不正なチャンネルIDを拒否（小文字）",
   assertEquals(result.success, false);
 });
 
-Deno.test("channelIdSchema: 不正なチャンネルIDを拒否（Cで開始しない）", () => {
+Deno.test("channelIdSchema: 不正なチャンネルIDを拒否（無効なプレフィックス）", () => {
+  // U はユーザーIDなのでチャンネルIDとしては無効
   const result = channelIdSchema.safeParse("U12345678");
   assertEquals(result.success, false);
 });
@@ -106,7 +123,7 @@ Deno.test({
     if (!result.success) {
       assertEquals(
         result.error.errors[0].message,
-        "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
+        "Channel ID must start with 'C' (public), 'G' (private), or 'D' (DM) followed by uppercase alphanumeric characters",
       );
     }
     setLocale(originalLocale); // 元に戻す
@@ -126,7 +143,7 @@ Deno.test({
     if (!result.success) {
       // 日本語のエラーメッセージを確認（部分一致）
       assertEquals(
-        result.error.errors[0].message.includes("チャンネルID"),
+        result.error.errors[0].message.includes("チャネルID"),
         true,
       );
     }
@@ -228,7 +245,7 @@ Deno.test({
     if (!result1.success) {
       assertEquals(
         result1.error.errors[0].message,
-        "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
+        "Channel ID must start with 'C' (public), 'G' (private), or 'D' (DM) followed by uppercase alphanumeric characters",
       );
     }
 
@@ -239,7 +256,7 @@ Deno.test({
     if (!result2.success) {
       // 日本語のエラーメッセージが表示される
       assertEquals(
-        result2.error.errors[0].message.includes("チャンネルID"),
+        result2.error.errors[0].message.includes("チャネルID"),
         true,
       );
     }
@@ -252,7 +269,7 @@ Deno.test({
       // 再び英語のエラーメッセージが表示される
       assertEquals(
         result3.error.errors[0].message,
-        "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
+        "Channel ID must start with 'C' (public), 'G' (private), or 'D' (DM) followed by uppercase alphanumeric characters",
       );
     }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -24,7 +24,7 @@
     "not_authorized_approver": "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
     "validation": {
       "channel_id_empty": "Channel ID cannot be empty",
-      "channel_id_format": "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
+      "channel_id_format": "Channel ID must start with 'C' (public), 'G' (private), or 'D' (DM) followed by uppercase alphanumeric characters",
       "user_id_empty": "User ID cannot be empty",
       "user_id_format": "User ID must start with 'U' or 'W' followed by uppercase alphanumeric characters",
       "value_empty": "Value cannot be empty",

--- a/locales/en.json
+++ b/locales/en.json
@@ -18,6 +18,7 @@
     "channel_info_failed": "Failed to get channel info: {error}",
     "missing_notification_channel": "Notification channel ID is required",
     "missing_admin_token": "Admin user token (SLACK_ADMIN_USER_TOKEN) is not configured",
+    "fetch_authorized_users_failed": "Failed to fetch authorized users: {error}",
     "not_authorized_approver": "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
     "validation": {
       "channel_id_empty": "Channel ID cannot be empty",
@@ -62,6 +63,8 @@
     "sending_approval_request": "Sending approval request for channel '{channel}' to approver '{approver}'",
     "approval_request_sent": "Approval request sent successfully",
     "creating_channel_after_approval": "Creating channel '{name}' after approval",
-    "members_invited": "{count} members invited to the channel"
+    "members_invited": "{count} members invited to the channel",
+    "fetching_authorized_users": "Fetching authorized users for team: {teamId}",
+    "authorized_users_fetched": "Found {count} authorized users (admins/owners)"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,6 +19,8 @@
     "missing_notification_channel": "Notification channel ID is required",
     "missing_admin_token": "Admin user token (SLACK_ADMIN_USER_TOKEN) is not configured",
     "fetch_authorized_users_failed": "Failed to fetch authorized users: {error}",
+    "no_authorized_users": "No authorized users found. Please ensure there are admins or owners in the workspace.",
+    "modal_open_failed": "Failed to open the form: {error}",
     "not_authorized_approver": "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
     "validation": {
       "channel_id_empty": "Channel ID cannot be empty",
@@ -50,6 +52,21 @@
     "approved_at": "Approved at {time}",
     "denied_at": "Denied at {time}"
   },
+  "form": {
+    "title": "Request Private Channel",
+    "submit_button": "Request",
+    "cancel_button": "Cancel",
+    "channel_name_label": "Channel Name",
+    "channel_name_placeholder": "project-alpha",
+    "channel_name_hint": "Name of the private channel (without #). Will be converted to lowercase.",
+    "approver_label": "Approver",
+    "approver_placeholder": "Select an approver",
+    "approver_hint": "Only admins and owners can approve private channel creation.",
+    "description_label": "Description",
+    "description_placeholder": "What is this channel for?",
+    "initial_members_label": "Initial Members",
+    "initial_members_placeholder": "Select members to invite"
+  },
   "logs": {
     "starting": "Starting workflow...",
     "completed": "Workflow completed",
@@ -65,6 +82,8 @@
     "creating_channel_after_approval": "Creating channel '{name}' after approval",
     "members_invited": "{count} members invited to the channel",
     "fetching_authorized_users": "Fetching authorized users for team: {teamId}",
-    "authorized_users_fetched": "Found {count} authorized users (admins/owners)"
+    "authorized_users_fetched": "Found {count} authorized users (admins/owners)",
+    "opening_form_with_authorized_users": "Opening form with {count} authorized users",
+    "modal_opened": "Modal opened successfully"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -84,6 +84,7 @@
     "fetching_authorized_users": "Fetching authorized users for team: {teamId}",
     "authorized_users_fetched": "Found {count} authorized users (admins/owners)",
     "opening_form_with_authorized_users": "Opening form with {count} authorized users",
-    "modal_opened": "Modal opened successfully"
+    "modal_opened": "Modal opened successfully",
+    "max_page_limit_reached": "Maximum page limit ({limit}) reached, stopping pagination"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -18,6 +18,9 @@
     "channel_info_failed": "チャネル情報の取得に失敗しました: {error}",
     "missing_notification_channel": "通知チャネルIDが必要です",
     "missing_admin_token": "管理者ユーザートークン(SLACK_ADMIN_USER_TOKEN)が設定されていません",
+    "fetch_authorized_users_failed": "認可ユーザーの取得に失敗しました: {error}",
+    "no_authorized_users": "認可ユーザーが見つかりません。ワークスペースに管理者またはオーナーがいることを確認してください。",
+    "modal_open_failed": "フォームを開くことができませんでした: {error}",
     "not_authorized_approver": "⚠️ このリクエストを承認する権限がありません。<@{approver}>のみが承認または却下できます。",
     "validation": {
       "channel_id_empty": "チャネルIDを空にすることはできません",
@@ -49,6 +52,21 @@
     "approved_at": "{time}に承認されました",
     "denied_at": "{time}に却下されました"
   },
+  "form": {
+    "title": "プライベートチャンネルをリクエスト",
+    "submit_button": "リクエスト",
+    "cancel_button": "キャンセル",
+    "channel_name_label": "チャンネル名",
+    "channel_name_placeholder": "project-alpha",
+    "channel_name_hint": "プライベートチャンネルの名前（#なし）。小文字に変換されます。",
+    "approver_label": "承認者",
+    "approver_placeholder": "承認者を選択してください",
+    "approver_hint": "管理者とオーナーのみがプライベートチャンネルの作成を承認できます。",
+    "description_label": "説明",
+    "description_placeholder": "このチャンネルの目的は？",
+    "initial_members_label": "初期メンバー",
+    "initial_members_placeholder": "招待するメンバーを選択してください"
+  },
   "logs": {
     "starting": "ワークフローを開始しています...",
     "completed": "ワークフローが完了しました",
@@ -62,6 +80,11 @@
     "sending_approval_request": "チャネル'{channel}'の承認リクエストを承認者'{approver}'に送信中です",
     "approval_request_sent": "承認リクエストが正常に送信されました",
     "creating_channel_after_approval": "承認後、チャネル'{name}'を作成中です",
-    "members_invited": "{count}人のメンバーがチャネルに招待されました"
+    "members_invited": "{count}人のメンバーがチャネルに招待されました",
+    "fetching_authorized_users": "チーム {teamId} の認可ユーザーを取得中です",
+    "authorized_users_fetched": "{count}人の認可ユーザー（管理者/オーナー）が見つかりました",
+    "opening_form_with_authorized_users": "{count}人の認可ユーザーでフォームを開いています",
+    "modal_opened": "モーダルが正常に開きました",
+    "max_page_limit_reached": "最大ページ数（{limit}）に達したため、ページネーションを停止します"
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -24,7 +24,7 @@
     "not_authorized_approver": "⚠️ このリクエストを承認する権限がありません。<@{approver}>のみが承認または却下できます。",
     "validation": {
       "channel_id_empty": "チャネルIDを空にすることはできません",
-      "channel_id_format": "チャネルIDは'C'で始まり、その後に大文字の英数字が続く必要があります",
+      "channel_id_format": "チャネルIDは'C'（パブリック）、'G'（プライベート）、または'D'（DM）で始まり、その後に大文字の英数字が続く必要があります",
       "user_id_empty": "ユーザーIDを空にすることはできません",
       "user_id_format": "ユーザーIDは'U'または'W'で始まり、その後に大文字の英数字が続く必要があります",
       "value_empty": "値を空にすることはできません",

--- a/manifest.ts
+++ b/manifest.ts
@@ -3,10 +3,13 @@ import { ExampleFunctionDefinition } from "./functions/example_function/mod.ts";
 import { GetChannelMembersDefinition } from "./functions/get_channel_members/mod.ts";
 import { CreatePrivateChannelDefinition } from "./functions/create_private_channel/mod.ts";
 import { RequestPrivateChannelDefinition } from "./functions/request_private_channel/mod.ts";
+import { GetAuthorizedUsersDefinition } from "./functions/get_authorized_users/mod.ts";
+import { ShowPrivateChannelFormDefinition } from "./functions/show_private_channel_form/mod.ts";
 import CreateChannelWorkflow from "./workflows/create_channel_workflow.ts";
 import RequestPrivateChannelWorkflow from "./workflows/request_private_channel_workflow.ts";
 import ExampleWorkflow from "./workflows/example_workflow.ts";
 import GetMembersWorkflow from "./workflows/get_members_workflow.ts";
+import { AuthorizedUserType } from "./lib/types/authorized_user.ts";
 
 // Load from environment variables with fallback defaults
 const APP_NAME = Deno.env.get("SLACK_APP_NAME") || "Slack Utils Template";
@@ -17,6 +20,7 @@ export default Manifest({
   name: APP_NAME,
   description: APP_DESCRIPTION,
   icon: "assets/icon.png",
+  types: [AuthorizedUserType],
   workflows: [
     ExampleWorkflow,
     GetMembersWorkflow,
@@ -28,6 +32,8 @@ export default Manifest({
     GetChannelMembersDefinition,
     CreatePrivateChannelDefinition,
     RequestPrivateChannelDefinition,
+    GetAuthorizedUsersDefinition,
+    ShowPrivateChannelFormDefinition,
   ],
   outgoingDomains: [], // slack.com はデフォルトで許可済み
   botScopes: [

--- a/workflows/request_private_channel_workflow.ts
+++ b/workflows/request_private_channel_workflow.ts
@@ -37,18 +37,21 @@ const RequestPrivateChannelWorkflow = DefineWorkflow({
 });
 
 // Step 1: 権限を持つユーザー（管理者/オーナー）を取得
+// interactivityを入力として渡し、出力としてStep 2に引き継ぐ
 const getAuthorizedUsersStep = RequestPrivateChannelWorkflow.addStep(
   GetAuthorizedUsersDefinition,
   {
+    interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
     channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
   },
 );
 
 // Step 2: フィルタリングされた承認者リストを使用してフォームを表示
+// interactivityはStep 1の出力から取得
 RequestPrivateChannelWorkflow.addStep(
   ShowPrivateChannelFormDefinition,
   {
-    interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
+    interactivity: getAuthorizedUsersStep.outputs.interactivity,
     user_id: RequestPrivateChannelWorkflow.inputs.user_id,
     channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
     authorized_users: getAuthorizedUsersStep.outputs.authorized_users,

--- a/workflows/request_private_channel_workflow.ts
+++ b/workflows/request_private_channel_workflow.ts
@@ -1,5 +1,6 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
-import { RequestPrivateChannelDefinition } from "../functions/request_private_channel/mod.ts";
+import { GetAuthorizedUsersDefinition } from "../functions/get_authorized_users/mod.ts";
+import { ShowPrivateChannelFormDefinition } from "../functions/show_private_channel_form/mod.ts";
 
 /**
  * プライベートチャンネル作成リクエストワークフロー
@@ -7,6 +8,9 @@ import { RequestPrivateChannelDefinition } from "../functions/request_private_ch
  * 管理者の承認を経てプライベートチャンネルを作成します。
  * Admin API を使用するため、ワークスペースの権限設定に関係なく
  * プライベートチャンネルを作成できます。
+ *
+ * 承認者選択はプライベートチャンネル作成権限を持つユーザー
+ * （管理者/オーナー）のみに制限されます。
  */
 const RequestPrivateChannelWorkflow = DefineWorkflow({
   callback_id: "request_private_channel_workflow",
@@ -32,56 +36,22 @@ const RequestPrivateChannelWorkflow = DefineWorkflow({
   },
 });
 
-// Step 1: OpenFormでユーザー入力を取得
-const formStep = RequestPrivateChannelWorkflow.addStep(
-  Schema.slack.functions.OpenForm,
+// Step 1: 権限を持つユーザー（管理者/オーナー）を取得
+const getAuthorizedUsersStep = RequestPrivateChannelWorkflow.addStep(
+  GetAuthorizedUsersDefinition,
   {
-    title: "Request Private Channel",
-    interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
-    submit_label: "Request",
-    fields: {
-      elements: [
-        {
-          name: "channel_name",
-          title: "Channel Name",
-          type: Schema.types.string,
-          description: "Name of the private channel (without #)",
-        },
-        {
-          name: "approver_id",
-          title: "Approver",
-          type: Schema.slack.types.user_id,
-          description: "Administrator who will approve this request",
-        },
-        {
-          name: "description",
-          title: "Description",
-          type: Schema.types.string,
-          description: "Channel description (optional)",
-        },
-        {
-          name: "initial_members",
-          title: "Initial Members",
-          type: Schema.types.array,
-          items: { type: Schema.slack.types.user_id },
-          description: "Users to invite to the channel (optional)",
-        },
-      ],
-      required: ["channel_name", "approver_id"],
-    },
+    channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
   },
 );
 
-// Step 2: 承認リクエスト関数を呼び出し
+// Step 2: フィルタリングされた承認者リストを使用してフォームを表示
 RequestPrivateChannelWorkflow.addStep(
-  RequestPrivateChannelDefinition,
+  ShowPrivateChannelFormDefinition,
   {
-    channel_name: formStep.outputs.fields.channel_name,
-    requester_id: RequestPrivateChannelWorkflow.inputs.user_id,
-    approver_id: formStep.outputs.fields.approver_id,
-    approval_channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
-    description: formStep.outputs.fields.description,
-    initial_members: formStep.outputs.fields.initial_members,
+    interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
+    user_id: RequestPrivateChannelWorkflow.inputs.user_id,
+    channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
+    authorized_users: getAuthorizedUsersStep.outputs.authorized_users,
   },
 );
 


### PR DESCRIPTION
- Introduced AuthorizedUserType to standardize user data for private channel approvals.
- Updated get_authorized_users and show_private_channel_form functions to utilize the new type.
- Modified workflows to pass interactivity context and handle pagination limits.
- Added new i18n messages for improved user feedback and error handling.
- Enhanced tests to cover new functionality and ensure robustness.

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
