### PR TITLE
Add approvers to private channel creation

### DIFF
--- a/functions/request_private_channel/mod.ts
+++ b/functions/request_private_channel/mod.ts
@@ -413,8 +413,12 @@ export default SlackFunction(
           return await response.json();
         };
 
-        // リクエスト者と初期メンバーをまとめて招待
+        // リクエスト者と承認者と初期メンバーをまとめて招待
         const allMembersToInvite = [requesterId];
+        // Add the approver to the channel
+        if (approverId && !allMembersToInvite.includes(approverId)) {
+          allMembersToInvite.push(approverId);
+        }
         for (const member of initialMembers) {
           if (!allMembersToInvite.includes(member)) {
             allMembersToInvite.push(member);

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -583,6 +583,10 @@ export default SlackFunction(
         };
 
         const allMembersToInvite = [requesterId];
+        // Add the approver to the channel
+        if (approverId && !allMembersToInvite.includes(approverId)) {
+          allMembersToInvite.push(approverId);
+        }
         for (const member of initialMembers) {
           if (!allMembersToInvite.includes(member)) {
             allMembersToInvite.push(member);


### PR DESCRIPTION
When a private channel creation request is approved, the approver is now automatically added as a member of the newly created channel, in addition to the requester and initial members.

プライベートチャンネル作成時、承認者もチャンネルに追加する

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
