### PR TITLE
Set default language to Japanese for triggers and steps

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          LOCALE: ja
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
             deno test --allow-all

--- a/functions/create_private_channel/test.ts
+++ b/functions/create_private_channel/test.ts
@@ -350,7 +350,8 @@ Deno.test({
     );
 
     // 正規化後に空文字になるため、invalid_channel_nameエラー
-    assertEquals(error.message.includes("Invalid channel name"), true);
+    // デフォルトロケールは日本語
+    assertEquals(error.message.includes("無効なチャンネル名です"), true);
   },
 });
 

--- a/lib/i18n/mod.ts
+++ b/lib/i18n/mod.ts
@@ -7,7 +7,7 @@
 
 type LocaleData = Record<string, unknown>;
 
-let currentLocale = "en";
+let currentLocale = "ja";
 const localeCache: Map<string, LocaleData> = new Map();
 
 /**
@@ -319,26 +319,26 @@ export function getLocale(): string {
 /**
  * Detect locale from environment variables
  *
- * Checks LOCALE, LANG, and defaults to "en"
+ * Checks LOCALE, LANG, and defaults to "ja"
  *
  * @returns Detected locale code
  */
 export function detectLocale(): SupportedLocale {
   try {
     // Check LOCALE environment variable first
-    const locale = Deno.env.get("LOCALE") || Deno.env.get("LANG") || "en";
+    const locale = Deno.env.get("LOCALE") || Deno.env.get("LANG") || "ja";
 
     // Extract language code (e.g., "ja_JP.UTF-8" -> "ja")
     const langCode = locale.split(/[_.]/)[0].toLowerCase();
 
-    // Return if supported, otherwise default to English
+    // Return if supported, otherwise default to Japanese
     return SUPPORTED_LOCALES.includes(langCode as SupportedLocale)
       ? langCode as SupportedLocale
-      : "en";
+      : "ja";
   } catch (_error) {
     // Environment variable access not allowed (e.g., in production environment)
-    // Default to English
-    return "en";
+    // Default to Japanese
+    return "ja";
   }
 }
 

--- a/lib/i18n/test.ts
+++ b/lib/i18n/test.ts
@@ -11,7 +11,7 @@ import {
 import { checkI18n } from "./check.ts";
 
 Deno.test({
-  name: "detectLocale: デフォルトは英語",
+  name: "detectLocale: デフォルトは日本語",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: () => {
@@ -23,7 +23,7 @@ Deno.test({
       Deno.env.delete("LANG");
 
       const locale = detectLocale();
-      assertEquals(locale, "en");
+      assertEquals(locale, "ja");
     } finally {
       if (originalLocale) Deno.env.set("LOCALE", originalLocale);
       if (originalLang) Deno.env.set("LANG", originalLang);

--- a/triggers/create_channel_trigger.ts
+++ b/triggers/create_channel_trigger.ts
@@ -13,8 +13,8 @@ import CreateChannelWorkflow from "../workflows/create_channel_workflow.ts";
 
 const CreateChannelTrigger: Trigger<typeof CreateChannelWorkflow.definition> = {
   type: TriggerTypes.Shortcut,
-  name: "Create Channel",
-  description: "Create a new channel (public or private) with detailed logging",
+  name: "チャンネルを作成",
+  description: "新しいチャンネル（パブリックまたはプライベート）を作成します",
   workflow: `#/workflows/${CreateChannelWorkflow.definition.callback_id}`,
   inputs: {
     interactivity: {

--- a/triggers/example_trigger.ts
+++ b/triggers/example_trigger.ts
@@ -3,12 +3,12 @@ import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 import ExampleWorkflow from "../workflows/example_workflow.ts";
 
 // Load category from environment variable
-const CATEGORY = Deno.env.get("SLACK_CATEGORY") || "Channel";
+const CATEGORY = Deno.env.get("SLACK_CATEGORY") || "チャンネル";
 
 const ExampleTrigger: Trigger<typeof ExampleWorkflow.definition> = {
   type: TriggerTypes.Shortcut,
-  name: `Run ${CATEGORY} Lookup`,
-  description: `Lookup ${CATEGORY.toLowerCase()} information`,
+  name: `${CATEGORY}情報を検索`,
+  description: `${CATEGORY}情報を取得します`,
   workflow: `#/workflows/${ExampleWorkflow.definition.callback_id}`,
   inputs: {
     channel_id: {

--- a/triggers/get_members_trigger.ts
+++ b/triggers/get_members_trigger.ts
@@ -9,8 +9,8 @@ import GetMembersWorkflow from "../workflows/get_members_workflow.ts";
  */
 const GetMembersTrigger: Trigger<typeof GetMembersWorkflow.definition> = {
   type: TriggerTypes.Shortcut,
-  name: "Get Channel Members",
-  description: "Retrieve all members in the current channel",
+  name: "チャンネルメンバーを取得",
+  description: "現在のチャンネルの全メンバーを取得します",
   workflow: `#/workflows/${GetMembersWorkflow.definition.callback_id}`,
   inputs: {
     channel_id: {

--- a/triggers/request_private_channel_trigger.ts
+++ b/triggers/request_private_channel_trigger.ts
@@ -12,9 +12,8 @@ const RequestPrivateChannelTrigger: Trigger<
   typeof RequestPrivateChannelWorkflow.definition
 > = {
   type: TriggerTypes.Shortcut,
-  name: "Request Private Channel",
-  description:
-    "Request approval for private channel creation from an administrator",
+  name: "プライベートチャンネルをリクエスト",
+  description: "管理者にプライベートチャンネルの作成承認をリクエストします",
   workflow:
     `#/workflows/${RequestPrivateChannelWorkflow.definition.callback_id}`,
   inputs: {

--- a/workflows/create_channel_workflow.ts
+++ b/workflows/create_channel_workflow.ts
@@ -10,22 +10,21 @@ import { CreatePrivateChannelDefinition } from "../functions/create_private_chan
  */
 const CreateChannelWorkflow = DefineWorkflow({
   callback_id: "create_channel_workflow",
-  title: "Create Channel",
-  description: "Create a new channel (public or private) with detailed logging",
+  title: "チャンネルを作成",
+  description: "新しいチャンネル（パブリックまたはプライベート）を作成します",
   input_parameters: {
     properties: {
       interactivity: {
         type: Schema.slack.types.interactivity,
-        description: "Interactivity context for opening forms",
+        description: "フォームを開くためのインタラクティブコンテキスト",
       },
       user_id: {
         type: Schema.slack.types.user_id,
-        description:
-          "User ID of the workflow executor (required for channel creation)",
+        description: "ワークフロー実行者のユーザーID（チャンネル作成に必要）",
       },
       notification_channel: {
         type: Schema.slack.types.channel_id,
-        description: "Channel to send notification",
+        description: "通知を送信するチャンネル",
       },
     },
     required: ["interactivity", "user_id", "notification_channel"],
@@ -36,36 +35,36 @@ const CreateChannelWorkflow = DefineWorkflow({
 const formStep = CreateChannelWorkflow.addStep(
   Schema.slack.functions.OpenForm,
   {
-    title: "Create Channel",
+    title: "チャンネルを作成",
     interactivity: CreateChannelWorkflow.inputs.interactivity,
-    submit_label: "Create",
+    submit_label: "作成",
     fields: {
       elements: [
         {
           name: "channel_name",
-          title: "Channel Name",
+          title: "チャンネル名",
           type: Schema.types.string,
-          description: "Name of the channel (without #)",
+          description: "チャンネル名（#なし）",
         },
         {
           name: "is_private",
-          title: "Private Channel",
+          title: "プライベートチャンネル",
           type: Schema.types.boolean,
-          description: "Create as private channel (uncheck for public)",
+          description: "プライベートチャンネルとして作成（パブリックの場合はチェックを外す）",
           default: true,
         },
         {
           name: "description",
-          title: "Description",
+          title: "説明",
           type: Schema.types.string,
-          description: "Channel description (optional)",
+          description: "チャンネルの説明（任意）",
         },
         {
           name: "initial_members",
-          title: "Initial Members",
+          title: "初期メンバー",
           type: Schema.types.array,
           items: { type: Schema.slack.types.user_id },
-          description: "Users to invite to the channel (optional)",
+          description: "チャンネルに招待するユーザー（任意）",
         },
       ],
       required: ["channel_name"],
@@ -90,7 +89,7 @@ const createStep = CreateChannelWorkflow.addStep(
 CreateChannelWorkflow.addStep(Schema.slack.functions.SendMessage, {
   channel_id: CreateChannelWorkflow.inputs.notification_channel,
   message:
-    `✅ Channel created: <#${createStep.outputs.channel_id}>\nMembers: ${createStep.outputs.member_count}`,
+    `✅ チャンネルを作成しました: <#${createStep.outputs.channel_id}>\nメンバー数: ${createStep.outputs.member_count}`,
 });
 
 export default CreateChannelWorkflow;

--- a/workflows/create_channel_workflow.ts
+++ b/workflows/create_channel_workflow.ts
@@ -50,7 +50,8 @@ const formStep = CreateChannelWorkflow.addStep(
           name: "is_private",
           title: "プライベートチャンネル",
           type: Schema.types.boolean,
-          description: "プライベートチャンネルとして作成（パブリックの場合はチェックを外す）",
+          description:
+            "プライベートチャンネルとして作成（パブリックの場合はチェックを外す）",
           default: true,
         },
         {

--- a/workflows/example_workflow.ts
+++ b/workflows/example_workflow.ts
@@ -2,17 +2,17 @@ import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
 import { ExampleFunctionDefinition } from "../functions/example_function/mod.ts";
 
 // Load category from environment variable
-const CATEGORY = Deno.env.get("SLACK_CATEGORY") || "Channel";
+const CATEGORY = Deno.env.get("SLACK_CATEGORY") || "チャンネル";
 
 const ExampleWorkflow = DefineWorkflow({
   callback_id: "example_workflow",
-  title: `${CATEGORY} Explorer`,
-  description: `Explore ${CATEGORY.toLowerCase()} information`,
+  title: `${CATEGORY}エクスプローラー`,
+  description: `${CATEGORY}情報を探索します`,
   input_parameters: {
     properties: {
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: `Target ${CATEGORY.toLowerCase()} ID`,
+        description: `対象${CATEGORY}ID`,
       },
     },
     required: ["channel_id"],

--- a/workflows/get_members_workflow.ts
+++ b/workflows/get_members_workflow.ts
@@ -8,13 +8,13 @@ import { GetChannelMembersDefinition } from "../functions/get_channel_members/mo
  */
 const GetMembersWorkflow = DefineWorkflow({
   callback_id: "get_members_workflow",
-  title: "Get Channel Members",
-  description: "Retrieve all members in a channel",
+  title: "チャンネルメンバーを取得",
+  description: "チャンネルの全メンバーを取得します",
   input_parameters: {
     properties: {
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "Target channel ID",
+        description: "対象チャンネルID",
       },
     },
     required: ["channel_id"],
@@ -32,8 +32,7 @@ GetMembersWorkflow.addStep(
 // 結果をメッセージで表示
 GetMembersWorkflow.addStep(Schema.slack.functions.SendMessage, {
   channel_id: GetMembersWorkflow.inputs.channel_id,
-  message:
-    "✅ Channel members retrieved! Check the workflow output for details.",
+  message: "✅ チャンネルメンバーを取得しました！詳細はワークフロー出力を確認してください。",
 });
 
 export default GetMembersWorkflow;

--- a/workflows/get_members_workflow.ts
+++ b/workflows/get_members_workflow.ts
@@ -32,7 +32,8 @@ GetMembersWorkflow.addStep(
 // 結果をメッセージで表示
 GetMembersWorkflow.addStep(Schema.slack.functions.SendMessage, {
   channel_id: GetMembersWorkflow.inputs.channel_id,
-  message: "✅ チャンネルメンバーを取得しました！詳細はワークフロー出力を確認してください。",
+  message:
+    "✅ チャンネルメンバーを取得しました！詳細はワークフロー出力を確認してください。",
 });
 
 export default GetMembersWorkflow;

--- a/workflows/request_private_channel_workflow.ts
+++ b/workflows/request_private_channel_workflow.ts
@@ -14,22 +14,21 @@ import { ShowPrivateChannelFormDefinition } from "../functions/show_private_chan
  */
 const RequestPrivateChannelWorkflow = DefineWorkflow({
   callback_id: "request_private_channel_workflow",
-  title: "Request Private Channel",
-  description:
-    "Request approval for private channel creation from an administrator",
+  title: "プライベートチャンネルをリクエスト",
+  description: "管理者にプライベートチャンネルの作成承認をリクエストします",
   input_parameters: {
     properties: {
       interactivity: {
         type: Schema.slack.types.interactivity,
-        description: "Interactivity context for opening forms",
+        description: "フォームを開くためのインタラクティブコンテキスト",
       },
       user_id: {
         type: Schema.slack.types.user_id,
-        description: "User ID of the requester",
+        description: "リクエスト者のユーザーID",
       },
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "Channel where the request was made",
+        description: "リクエストが行われたチャンネル",
       },
     },
     required: ["interactivity", "user_id", "channel_id"],


### PR DESCRIPTION
- lib/i18n/mod.ts: デフォルトロケールを en から ja に変更
- トリガーの name/description を日本語化
- ワークフローの title/description/フォームラベルを日本語化

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
