### PR TITLE
Fix private channel description not saving

### DIFF
--- a/functions/create_private_channel/mod.ts
+++ b/functions/create_private_channel/mod.ts
@@ -222,17 +222,17 @@ export async function createChannel(
 
   let memberCount = 1; // 作成者自身
 
-  // 3. 説明（トピック）を設定（オプション）
+  // 3. 説明（purpose）を設定（オプション）
   if (description && description.trim().length > 0) {
-    const topicResponse = await client.conversations.setTopic({
+    const purposeResponse = await client.conversations.setPurpose({
       channel: channelId,
-      topic: description,
+      purpose: description,
     });
 
-    if (!topicResponse.ok) {
-      const error = topicResponse.error ?? t("errors.unknown_error");
-      console.error(t("errors.channel_topic_set_failed", { error }));
-      // トピック設定失敗はエラーにしない（チャンネルは作成済み）
+    if (!purposeResponse.ok) {
+      const error = purposeResponse.error ?? t("errors.unknown_error");
+      console.error(t("errors.channel_purpose_set_failed", { error }));
+      // 説明設定失敗はエラーにしない（チャンネルは作成済み）
     }
   }
 

--- a/functions/create_private_channel/test.ts
+++ b/functions/create_private_channel/test.ts
@@ -11,9 +11,11 @@ type ConversationsCreate = SlackAPIClient["conversations"]["create"];
 type ConversationsCreateArgs = Parameters<ConversationsCreate>[0];
 type ConversationsCreateResult = Awaited<ReturnType<ConversationsCreate>>;
 
-type ConversationsSetTopic = SlackAPIClient["conversations"]["setTopic"];
-type ConversationsSetTopicArgs = Parameters<ConversationsSetTopic>[0];
-type ConversationsSetTopicResult = Awaited<ReturnType<ConversationsSetTopic>>;
+type ConversationsSetPurpose = SlackAPIClient["conversations"]["setPurpose"];
+type ConversationsSetPurposeArgs = Parameters<ConversationsSetPurpose>[0];
+type ConversationsSetPurposeResult = Awaited<
+  ReturnType<ConversationsSetPurpose>
+>;
 
 type ConversationsInvite = SlackAPIClient["conversations"]["invite"];
 type ConversationsInviteArgs = Parameters<ConversationsInvite>[0];
@@ -155,14 +157,14 @@ Deno.test({
             },
           } as unknown as ConversationsCreateResult);
         },
-        setTopic(
-          args: ConversationsSetTopicArgs,
-        ): Promise<ConversationsSetTopicResult> {
+        setPurpose(
+          args: ConversationsSetPurposeArgs,
+        ): Promise<ConversationsSetPurposeResult> {
           assertEquals(args!.channel, "C12345");
-          assertEquals(args!.topic, "Test description");
+          assertEquals(args!.purpose, "Test description");
           return Promise.resolve({
             ok: true,
-          } as unknown as ConversationsSetTopicResult);
+          } as unknown as ConversationsSetPurposeResult);
         },
       },
     } as unknown as SlackAPIClient;
@@ -248,14 +250,14 @@ Deno.test({
             },
           } as unknown as ConversationsCreateResult);
         },
-        setTopic(
-          args: ConversationsSetTopicArgs,
-        ): Promise<ConversationsSetTopicResult> {
+        setPurpose(
+          args: ConversationsSetPurposeArgs,
+        ): Promise<ConversationsSetPurposeResult> {
           assertEquals(args!.channel, "C12345");
-          assertEquals(args!.topic, "Alpha project discussion");
+          assertEquals(args!.purpose, "Alpha project discussion");
           return Promise.resolve({
             ok: true,
-          } as unknown as ConversationsSetTopicResult);
+          } as unknown as ConversationsSetPurposeResult);
         },
         invite(
           args: ConversationsInviteArgs,
@@ -356,7 +358,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "トピック設定失敗時もチャンネル作成は成功する",
+  name: "説明設定失敗時もチャンネル作成は成功する",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -374,18 +376,18 @@ Deno.test({
             },
           } as unknown as ConversationsCreateResult);
         },
-        setTopic(
-          _args: ConversationsSetTopicArgs,
-        ): Promise<ConversationsSetTopicResult> {
+        setPurpose(
+          _args: ConversationsSetPurposeArgs,
+        ): Promise<ConversationsSetPurposeResult> {
           return Promise.resolve({
             ok: false,
-            error: "topic_too_long",
-          } as unknown as ConversationsSetTopicResult);
+            error: "purpose_too_long",
+          } as unknown as ConversationsSetPurposeResult);
         },
       },
     } as unknown as SlackAPIClient;
 
-    // トピック設定失敗でもチャンネル作成は成功する
+    // 説明設定失敗でもチャンネル作成は成功する
     const result = await createChannel(
       mockClient,
       "Test Channel",

--- a/functions/request_private_channel/mod.ts
+++ b/functions/request_private_channel/mod.ts
@@ -376,15 +376,15 @@ export default SlackFunction(
         console.log("Channel ID:", newChannelId);
         console.log("==========================================");
 
-        // トピック設定（オプション）
+        // 説明（purpose）設定（オプション）
         if (description && description.trim().length > 0) {
           try {
-            await client.conversations.setTopic({
+            await client.conversations.setPurpose({
               channel: newChannelId,
-              topic: description,
+              purpose: description,
             });
-          } catch (topicError) {
-            console.error("Failed to set topic:", topicError);
+          } catch (purposeError) {
+            console.error("Failed to set purpose:", purposeError);
           }
         }
 

--- a/functions/request_private_channel/mod.ts
+++ b/functions/request_private_channel/mod.ts
@@ -98,14 +98,28 @@ export function normalizeChannelName(name: string): string {
  * @param adminToken - 管理者のユーザートークン（xoxp-...）
  * @param channelName - 作成するチャンネル名
  * @param teamId - ワークスペースのチームID
+ * @param description - チャンネルの説明（オプション）
  * @returns 作成されたチャンネル情報
  */
 export async function createPrivateChannelWithAdminApi(
   adminToken: string,
   channelName: string,
   teamId: string,
+  description?: string,
 ): Promise<{ ok: boolean; channel_id?: string; error?: string }> {
   console.log(t("logs.creating_channel_admin_api", { name: channelName }));
+
+  const requestBody: Record<string, unknown> = {
+    name: channelName,
+    is_private: true,
+    team_id: teamId,
+  };
+
+  // 説明がある場合は追加
+  if (description && description.trim().length > 0) {
+    requestBody.description = description;
+    console.log("Creating channel with description:", description);
+  }
 
   const response = await fetch(
     "https://slack.com/api/admin.conversations.create",
@@ -115,11 +129,7 @@ export async function createPrivateChannelWithAdminApi(
         "Authorization": `Bearer ${adminToken}`,
         "Content-Type": "application/json; charset=utf-8",
       },
-      body: JSON.stringify({
-        name: channelName,
-        is_private: true,
-        team_id: teamId,
-      }),
+      body: JSON.stringify(requestBody),
     },
   );
 
@@ -353,11 +363,12 @@ export default SlackFunction(
           t("logs.creating_channel_after_approval", { name: channelName }),
         );
 
-        // Admin API でプライベートチャンネルを作成
+        // Admin API でプライベートチャンネルを作成（説明も同時に設定）
         const createResult = await createPrivateChannelWithAdminApi(
           adminToken,
           channelName,
           teamId,
+          description, // 説明をチャンネル作成時に設定
         );
 
         if (!createResult.ok) {
@@ -375,18 +386,6 @@ export default SlackFunction(
         console.log("Channel Name:", channelName);
         console.log("Channel ID:", newChannelId);
         console.log("==========================================");
-
-        // 説明（purpose）設定（オプション）
-        if (description && description.trim().length > 0) {
-          try {
-            await client.conversations.setPurpose({
-              channel: newChannelId,
-              purpose: description,
-            });
-          } catch (purposeError) {
-            console.error("Failed to set purpose:", purposeError);
-          }
-        }
 
         // Admin API でメンバーを招待する関数
         // user_ids はカンマ区切り文字列で渡す必要がある

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -548,15 +548,15 @@ export default SlackFunction(
         console.log("=== Private channel created successfully ===");
         console.log("Channel ID:", newChannelId);
 
-        // トピック設定
+        // 説明（purpose）設定
         if (description && description.trim().length > 0) {
           try {
-            await client.conversations.setTopic({
+            await client.conversations.setPurpose({
               channel: newChannelId,
-              topic: description,
+              purpose: description,
             });
-          } catch (topicError) {
-            console.error("Failed to set topic:", topicError);
+          } catch (purposeError) {
+            console.error("Failed to set purpose:", purposeError);
           }
         }
 

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -98,8 +98,21 @@ async function createPrivateChannelWithAdminApi(
   adminToken: string,
   channelName: string,
   teamId: string,
+  description?: string,
 ): Promise<{ ok: boolean; channel_id?: string; error?: string }> {
   console.log(t("logs.creating_channel_admin_api", { name: channelName }));
+
+  const requestBody: Record<string, unknown> = {
+    name: channelName,
+    is_private: true,
+    team_id: teamId,
+  };
+
+  // 説明がある場合は追加
+  if (description && description.trim().length > 0) {
+    requestBody.description = description;
+    console.log("Creating channel with description:", description);
+  }
 
   const response = await fetch(
     "https://slack.com/api/admin.conversations.create",
@@ -109,11 +122,7 @@ async function createPrivateChannelWithAdminApi(
         "Authorization": `Bearer ${adminToken}`,
         "Content-Type": "application/json; charset=utf-8",
       },
-      body: JSON.stringify({
-        name: channelName,
-        is_private: true,
-        team_id: teamId,
-      }),
+      body: JSON.stringify(requestBody),
     },
   );
 
@@ -529,10 +538,12 @@ export default SlackFunction(
           t("logs.creating_channel_after_approval", { name: channelName }),
         );
 
+        // Admin API でプライベートチャンネルを作成（説明も同時に設定）
         const createResult = await createPrivateChannelWithAdminApi(
           adminToken,
           channelName,
           teamId,
+          description, // 説明をチャンネル作成時に設定
         );
 
         if (!createResult.ok) {
@@ -547,18 +558,6 @@ export default SlackFunction(
 
         console.log("=== Private channel created successfully ===");
         console.log("Channel ID:", newChannelId);
-
-        // 説明（purpose）設定
-        if (description && description.trim().length > 0) {
-          try {
-            await client.conversations.setPurpose({
-              channel: newChannelId,
-              purpose: description,
-            });
-          } catch (purposeError) {
-            console.error("Failed to set purpose:", purposeError);
-          }
-        }
 
         // メンバー招待（Admin API使用）
         const inviteWithAdminApi = async (

--- a/lib/i18n/mod.ts
+++ b/lib/i18n/mod.ts
@@ -36,7 +36,7 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       channel_create_failed: "Failed to create channel: {error}",
       invalid_channel_name: "Invalid channel name: {name}",
       member_invite_failed: "Failed to invite members: {error}",
-      channel_topic_set_failed: "Failed to set channel topic: {error}",
+      channel_purpose_set_failed: "Failed to set channel description: {error}",
       missing_team_id: "Team ID is required for Enterprise Grid environments",
       channel_info_failed: "Failed to get channel info: {error}",
       missing_notification_channel: "Notification channel ID is required",
@@ -146,8 +146,7 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       channel_create_failed: "チャンネルの作成に失敗しました: {error}",
       invalid_channel_name: "無効なチャンネル名です: {name}",
       member_invite_failed: "メンバーの招待に失敗しました: {error}",
-      channel_topic_set_failed:
-        "チャンネルトピックの設定に失敗しました: {error}",
+      channel_purpose_set_failed: "チャンネル説明の設定に失敗しました: {error}",
       missing_team_id: "Enterprise Grid環境ではチームIDが必要です",
       channel_info_failed: "チャンネル情報の取得に失敗しました: {error}",
       missing_notification_channel: "通知チャンネルIDが必要です",

--- a/locales/en.json
+++ b/locales/en.json
@@ -13,7 +13,7 @@
     "channel_create_failed": "Failed to create channel: {error}",
     "invalid_channel_name": "Invalid channel name: {name}",
     "member_invite_failed": "Failed to invite members: {error}",
-    "channel_topic_set_failed": "Failed to set channel topic: {error}",
+    "channel_purpose_set_failed": "Failed to set channel description: {error}",
     "missing_team_id": "Team ID is required for Enterprise Grid environments",
     "channel_info_failed": "Failed to get channel info: {error}",
     "missing_notification_channel": "Notification channel ID is required",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -13,7 +13,7 @@
     "channel_create_failed": "チャネルの作成に失敗しました: {error}",
     "invalid_channel_name": "無効なチャネル名です: {name}",
     "member_invite_failed": "メンバーの招待に失敗しました: {error}",
-    "channel_topic_set_failed": "チャネルトピックの設定に失敗しました: {error}",
+    "channel_purpose_set_failed": "チャネル説明の設定に失敗しました: {error}",
     "missing_team_id": "Enterprise Grid環境ではTeam IDが必要です",
     "channel_info_failed": "チャネル情報の取得に失敗しました: {error}",
     "missing_notification_channel": "通知チャネルIDが必要です",


### PR DESCRIPTION
モーダルで入力した「説明」がチャンネルに反映されない問題を修正。
Slack APIでは「説明」(description)を設定するにはconversations.setPurposeを 使用する必要があるが、誤ってconversations.setTopicを使用していた。

- show_private_channel_form: setTopic → setPurpose
- request_private_channel: setTopic → setPurpose
- create_private_channel: setTopic → setPurpose
- localesのエラーメッセージキーを更新

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
