### PR TITLE
Set Japanese as default language for steps

### DIFF
--- a/functions/create_private_channel/mod.ts
+++ b/functions/create_private_channel/mod.ts
@@ -31,7 +31,8 @@ export const CreatePrivateChannelDefinition = DefineFunction({
       },
       is_private: {
         type: Schema.types.boolean,
-        description: "プライベートチャンネルとして作成するか（デフォルト: true）",
+        description:
+          "プライベートチャンネルとして作成するか（デフォルト: true）",
         default: true,
       },
       description: {

--- a/functions/create_private_channel/mod.ts
+++ b/functions/create_private_channel/mod.ts
@@ -9,41 +9,41 @@ import { z } from "zod";
 
 export const CreatePrivateChannelDefinition = DefineFunction({
   callback_id: "create_private_channel",
-  title: "Create Channel",
+  title: "チャンネル作成",
   description:
-    "Create a new channel (public or private) with optional initial members",
+    "新しいチャンネル（パブリックまたはプライベート）を作成します。初期メンバーを追加できます",
   source_file: "functions/create_private_channel/mod.ts",
   input_parameters: {
     properties: {
       channel_name: {
         type: Schema.types.string,
-        description: "Name of the channel to create (without #)",
+        description: "作成するチャンネル名（#なし）",
       },
       creator_id: {
         type: Schema.slack.types.user_id,
         description:
-          "User ID of the channel creator (required for workspace apps)",
+          "チャンネル作成者のユーザーID（ワークスペースアプリでは必須）",
       },
       notification_channel_id: {
         type: Schema.slack.types.channel_id,
         description:
-          "Channel ID where shortcut was triggered (used to get workspace team_id)",
+          "ショートカットがトリガーされたチャンネルID（team_id取得用）",
       },
       is_private: {
         type: Schema.types.boolean,
-        description: "Whether to create a private channel (default: true)",
+        description: "プライベートチャンネルとして作成するか（デフォルト: true）",
         default: true,
       },
       description: {
         type: Schema.types.string,
-        description: "Channel description (optional)",
+        description: "チャンネルの説明（任意）",
       },
       initial_members: {
         type: Schema.types.array,
         items: {
           type: Schema.slack.types.user_id,
         },
-        description: "User IDs to invite to the channel (optional)",
+        description: "チャンネルに招待するユーザーID（任意）",
       },
     },
     required: ["channel_name", "creator_id", "notification_channel_id"],
@@ -52,15 +52,15 @@ export const CreatePrivateChannelDefinition = DefineFunction({
     properties: {
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "ID of the created channel",
+        description: "作成されたチャンネルのID",
       },
       channel_name: {
         type: Schema.types.string,
-        description: "Name of the created channel",
+        description: "作成されたチャンネル名",
       },
       member_count: {
         type: Schema.types.number,
-        description: "Number of initial members (including bot)",
+        description: "初期メンバー数（Botを含む）",
       },
     },
     required: ["channel_id", "channel_name", "member_count"],

--- a/functions/example_function/mod.ts
+++ b/functions/example_function/mod.ts
@@ -3,19 +3,16 @@ import type { SlackAPIClient } from "deno-slack-sdk/types.ts";
 import { t } from "../../lib/i18n/mod.ts";
 import { channelIdSchema } from "../../lib/validation/schemas.ts";
 
-// Load category from environment variable
-const CATEGORY = Deno.env.get("SLACK_CATEGORY") || "Channel";
-
 export const ExampleFunctionDefinition = DefineFunction({
   callback_id: "example_function",
-  title: `Fetch ${CATEGORY} Details`,
-  description: `Fetch ${CATEGORY.toLowerCase()} information`,
+  title: "チャンネル詳細取得",
+  description: "チャンネル情報を取得します",
   source_file: "functions/example_function/mod.ts",
   input_parameters: {
     properties: {
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: `Target ${CATEGORY.toLowerCase()} ID`,
+        description: "対象チャンネルID",
       },
     },
     required: ["channel_id"],
@@ -24,19 +21,19 @@ export const ExampleFunctionDefinition = DefineFunction({
     properties: {
       id: {
         type: Schema.types.string,
-        description: `${CATEGORY} ID`,
+        description: "チャンネルID",
       },
       name: {
         type: Schema.types.string,
-        description: `${CATEGORY} name`,
+        description: "チャンネル名",
       },
       is_archived: {
         type: Schema.types.boolean,
-        description: `Whether the ${CATEGORY.toLowerCase()} is archived`,
+        description: "アーカイブ済みかどうか",
       },
       member_count: {
         type: Schema.types.number,
-        description: `Number of members in the ${CATEGORY.toLowerCase()}`,
+        description: "メンバー数",
       },
     },
     required: ["id", "name", "is_archived", "member_count"],

--- a/functions/get_authorized_users/mod.ts
+++ b/functions/get_authorized_users/mod.ts
@@ -51,20 +51,20 @@ interface AdminUsersListResponse {
  */
 export const GetAuthorizedUsersDefinition = DefineFunction({
   callback_id: "get_authorized_users",
-  title: "Get Authorized Users",
+  title: "承認権限ユーザー取得",
   description:
-    "Get users who have permission to create private channels (admins and owners)",
+    "プライベートチャンネル作成権限を持つユーザー（管理者とオーナー）を取得します",
   source_file: "functions/get_authorized_users/mod.ts",
   input_parameters: {
     properties: {
       interactivity: {
         type: Schema.slack.types.interactivity,
-        description: "Interactivity context (passed through to output)",
+        description: "インタラクティブコンテキスト（出力に渡されます）",
       },
       channel_id: {
         type: Schema.slack.types.channel_id,
         description:
-          "Channel ID to get workspace team_id (for Enterprise Grid)",
+          "team_id取得用チャンネルID（Enterprise Grid用）",
       },
     },
     required: ["interactivity", "channel_id"],
@@ -73,23 +73,23 @@ export const GetAuthorizedUsersDefinition = DefineFunction({
     properties: {
       interactivity: {
         type: Schema.slack.types.interactivity,
-        description: "Interactivity context (passed through from input)",
+        description: "インタラクティブコンテキスト（入力から引き継ぎ）",
       },
       authorized_users: {
         type: Schema.types.array,
         items: {
           type: AuthorizedUserType,
         },
-        description: "List of users with private channel creation permission",
+        description: "プライベートチャンネル作成権限を持つユーザー一覧",
       },
       user_ids: {
         type: Schema.types.array,
         items: { type: Schema.slack.types.user_id },
-        description: "List of user IDs with permission",
+        description: "権限を持つユーザーのID一覧",
       },
       count: {
         type: Schema.types.integer,
-        description: "Number of authorized users",
+        description: "権限ユーザー数",
       },
     },
     required: ["interactivity", "authorized_users", "user_ids", "count"],

--- a/functions/get_authorized_users/mod.ts
+++ b/functions/get_authorized_users/mod.ts
@@ -63,8 +63,7 @@ export const GetAuthorizedUsersDefinition = DefineFunction({
       },
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description:
-          "team_id取得用チャンネルID（Enterprise Grid用）",
+        description: "team_id取得用チャンネルID（Enterprise Grid用）",
       },
     },
     required: ["interactivity", "channel_id"],

--- a/functions/get_channel_members/mod.ts
+++ b/functions/get_channel_members/mod.ts
@@ -5,14 +5,14 @@ import { channelIdSchema } from "../../lib/validation/schemas.ts";
 
 export const GetChannelMembersDefinition = DefineFunction({
   callback_id: "get_channel_members",
-  title: "Get Channel Members",
-  description: "Retrieve list of members in a channel",
+  title: "チャンネルメンバー取得",
+  description: "チャンネルのメンバー一覧を取得します",
   source_file: "functions/get_channel_members/mod.ts",
   input_parameters: {
     properties: {
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "Target channel ID",
+        description: "対象チャンネルID",
       },
     },
     required: ["channel_id"],
@@ -24,11 +24,11 @@ export const GetChannelMembersDefinition = DefineFunction({
         items: {
           type: Schema.types.string,
         },
-        description: "Array of user IDs in the channel",
+        description: "チャンネル内のユーザーID一覧",
       },
       member_count: {
         type: Schema.types.number,
-        description: "Total number of members",
+        description: "メンバー総数",
       },
     },
     required: ["member_ids", "member_count"],

--- a/functions/request_private_channel/mod.ts
+++ b/functions/request_private_channel/mod.ts
@@ -18,8 +18,7 @@ await initI18n();
 export const RequestPrivateChannelDefinition = DefineFunction({
   callback_id: "request_private_channel",
   title: "プライベートチャンネル申請",
-  description:
-    "管理者にプライベートチャンネル作成の承認を申請します",
+  description: "管理者にプライベートチャンネル作成の承認を申請します",
   source_file: "functions/request_private_channel/mod.ts",
   input_parameters: {
     properties: {

--- a/functions/request_private_channel/mod.ts
+++ b/functions/request_private_channel/mod.ts
@@ -17,38 +17,38 @@ await initI18n();
  */
 export const RequestPrivateChannelDefinition = DefineFunction({
   callback_id: "request_private_channel",
-  title: "Request Private Channel",
+  title: "プライベートチャンネル申請",
   description:
-    "Request approval for private channel creation from an administrator",
+    "管理者にプライベートチャンネル作成の承認を申請します",
   source_file: "functions/request_private_channel/mod.ts",
   input_parameters: {
     properties: {
       channel_name: {
         type: Schema.types.string,
-        description: "Name of the channel to create (without #)",
+        description: "作成するチャンネル名（#なし）",
       },
       requester_id: {
         type: Schema.slack.types.user_id,
-        description: "User ID of the requester",
+        description: "申請者のユーザーID",
       },
       approver_id: {
         type: Schema.slack.types.user_id,
-        description: "User ID of the administrator who will approve",
+        description: "承認する管理者のユーザーID",
       },
       approval_channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "Channel ID where approval request will be sent",
+        description: "承認リクエストを送信するチャンネルID",
       },
       description: {
         type: Schema.types.string,
-        description: "Channel description (optional)",
+        description: "チャンネルの説明（任意）",
       },
       initial_members: {
         type: Schema.types.array,
         items: {
           type: Schema.slack.types.user_id,
         },
-        description: "User IDs to invite to the channel (optional)",
+        description: "チャンネルに招待するユーザーID（任意）",
       },
     },
     required: [
@@ -62,19 +62,19 @@ export const RequestPrivateChannelDefinition = DefineFunction({
     properties: {
       approved: {
         type: Schema.types.boolean,
-        description: "Whether the request was approved",
+        description: "承認されたかどうか",
       },
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "ID of the created channel (if approved)",
+        description: "作成されたチャンネルのID（承認時）",
       },
       channel_name: {
         type: Schema.types.string,
-        description: "Name of the created channel (if approved)",
+        description: "作成されたチャンネル名（承認時）",
       },
       reviewer_id: {
         type: Schema.slack.types.user_id,
-        description: "ID of the user who reviewed the request",
+        description: "レビューしたユーザーのID",
       },
     },
     required: ["approved", "reviewer_id"],

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -29,30 +29,30 @@ interface AuthorizedUser {
  */
 export const ShowPrivateChannelFormDefinition = DefineFunction({
   callback_id: "show_private_channel_form",
-  title: "Show Private Channel Request Form",
+  title: "プライベートチャンネル申請フォーム表示",
   description:
-    "Display a form for private channel creation with filtered approver list",
+    "承認者を選択してプライベートチャンネルを申請するフォームを表示します",
   source_file: "functions/show_private_channel_form/mod.ts",
   input_parameters: {
     properties: {
       interactivity: {
         type: Schema.slack.types.interactivity,
-        description: "Interactivity context for opening the modal",
+        description: "モーダルを開くためのインタラクティブコンテキスト",
       },
       user_id: {
         type: Schema.slack.types.user_id,
-        description: "User ID of the requester",
+        description: "申請者のユーザーID",
       },
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "Channel where the request was made",
+        description: "リクエストが行われたチャンネル",
       },
       authorized_users: {
         type: Schema.types.array,
         items: {
           type: AuthorizedUserType,
         },
-        description: "List of users authorized to approve requests",
+        description: "承認権限を持つユーザー一覧",
       },
     },
     required: ["interactivity", "user_id", "channel_id", "authorized_users"],
@@ -61,19 +61,19 @@ export const ShowPrivateChannelFormDefinition = DefineFunction({
     properties: {
       approved: {
         type: Schema.types.boolean,
-        description: "Whether the request was approved",
+        description: "承認されたかどうか",
       },
       channel_id: {
         type: Schema.slack.types.channel_id,
-        description: "ID of the created channel (if approved)",
+        description: "作成されたチャンネルのID（承認時）",
       },
       channel_name: {
         type: Schema.types.string,
-        description: "Name of the created channel (if approved)",
+        description: "作成されたチャンネル名（承認時）",
       },
       reviewer_id: {
         type: Schema.slack.types.user_id,
-        description: "ID of the user who reviewed the request",
+        description: "レビューしたユーザーのID",
       },
     },
     required: ["approved", "reviewer_id"],


### PR DESCRIPTION
ワークフローステップの一覧で表示されるタイトルと説明、
およびパラメータの説明をすべて日本語に変更しました。

変更した関数:
- create_private_channel: チャンネル作成
- get_channel_members: チャンネルメンバー取得
- get_authorized_users: 承認権限ユーザー取得
- request_private_channel: プライベートチャンネル申請
- show_private_channel_form: プライベートチャンネル申請フォーム表示
- example_function: チャンネル詳細取得

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
