### PR TITLE
Add private channel creation permission check

### DIFF
--- a/functions/check_private_channel_permissions/mod.ts
+++ b/functions/check_private_channel_permissions/mod.ts
@@ -33,23 +33,15 @@ export const CheckPrivateChannelPermissionsDefinition = DefineFunction({
   source_file: "functions/check_private_channel_permissions/mod.ts",
   input_parameters: {
     properties: {
-      interactivity: {
-        type: Schema.slack.types.interactivity,
-        description: "インタラクティブコンテキスト（出力に渡されます）",
-      },
       channel_id: {
         type: Schema.slack.types.channel_id,
         description: "team_id取得用チャンネルID（Enterprise Grid用）",
       },
     },
-    required: ["interactivity", "channel_id"],
+    required: ["channel_id"],
   },
   output_parameters: {
     properties: {
-      interactivity: {
-        type: Schema.slack.types.interactivity,
-        description: "インタラクティブコンテキスト（入力から引き継ぎ）",
-      },
       who_can_create_private_channels: {
         type: Schema.types.string,
         description:
@@ -61,7 +53,6 @@ export const CheckPrivateChannelPermissionsDefinition = DefineFunction({
       },
     },
     required: [
-      "interactivity",
       "who_can_create_private_channels",
       "is_everyone_allowed",
     ],
@@ -228,7 +219,6 @@ export default SlackFunction(
 
       return {
         outputs: {
-          interactivity: inputs.interactivity,
           who_can_create_private_channels: whoCanCreatePrivateChannels,
           is_everyone_allowed: isEveryoneAllowed,
         },

--- a/functions/check_private_channel_permissions/mod.ts
+++ b/functions/check_private_channel_permissions/mod.ts
@@ -29,8 +29,7 @@ interface AdminTeamsSettingsInfoResponse {
 export const CheckPrivateChannelPermissionsDefinition = DefineFunction({
   callback_id: "check_private_channel_permissions",
   title: "プライベートチャンネル作成権限確認",
-  description:
-    "ワークスペースのプライベートチャンネル作成権限設定を確認します",
+  description: "ワークスペースのプライベートチャンネル作成権限設定を確認します",
   source_file: "functions/check_private_channel_permissions/mod.ts",
   input_parameters: {
     properties: {
@@ -61,7 +60,11 @@ export const CheckPrivateChannelPermissionsDefinition = DefineFunction({
         description: "全員がプライベートチャンネルを作成可能かどうか",
       },
     },
-    required: ["interactivity", "who_can_create_private_channels", "is_everyone_allowed"],
+    required: [
+      "interactivity",
+      "who_can_create_private_channels",
+      "is_everyone_allowed",
+    ],
   },
 });
 
@@ -138,8 +141,8 @@ export async function getTeamSettings(
   console.log("admin.teams.settings.info response:", {
     ok: result.ok,
     error: result.error,
-    who_can_create_private_channels:
-      result.team?.who_can_create_private_channels,
+    who_can_create_private_channels: result.team
+      ?.who_can_create_private_channels,
   });
 
   if (!result.ok) {

--- a/functions/check_private_channel_permissions/mod.ts
+++ b/functions/check_private_channel_permissions/mod.ts
@@ -106,8 +106,12 @@ async function getWorkspaceTeamId(
  *
  * @param adminToken - 管理者のユーザートークン（xoxp-...）
  * @param teamId - ワークスペースのチームID
- * @returns ワークスペース設定情報
- * @throws {Error} APIリクエストに失敗した場合
+ * @returns ワークスペース設定情報（APIエラー時はデフォルト値を返す）
+ *
+ * @remarks
+ * このAPIには `admin.teams:read` スコープが必要です。
+ * スコープがない場合やAPIエラーの場合は、安全側に倒して
+ * 「承認が必要」（admin）として扱います。
  *
  * @example
  * ```typescript
@@ -118,8 +122,8 @@ async function getWorkspaceTeamId(
 export async function getTeamSettings(
   adminToken: string,
   teamId: string,
-): Promise<{ who_can_create_private_channels: string }> {
-  console.log(t("logs.fetching_team_settings", { teamId }));
+): Promise<{ who_can_create_private_channels: string; api_error?: string }> {
+  console.log(`Fetching team settings for team: ${teamId}`);
 
   const params = new URLSearchParams({
     team_id: teamId,
@@ -145,12 +149,19 @@ export async function getTeamSettings(
       ?.who_can_create_private_channels,
   });
 
+  // APIエラーの場合はデフォルト値を返す（承認が必要として扱う）
   if (!result.ok) {
-    throw new Error(
-      t("errors.fetch_team_settings_failed", {
-        error: result.error ?? t("errors.unknown_error"),
-      }),
+    const errorMsg = result.error ?? "unknown_error";
+    console.warn(
+      `Failed to fetch team settings (${errorMsg}). ` +
+        `Falling back to default: approval required. ` +
+        `Note: This API requires 'admin.teams:read' scope on the user token.`,
     );
+
+    return {
+      who_can_create_private_channels: "admin", // 安全側に倒す
+      api_error: errorMsg,
+    };
   }
 
   // デフォルトは "admin"（制限あり）として扱う
@@ -172,25 +183,47 @@ export default SlackFunction(
       // 環境変数から Admin User Token を取得
       const adminToken = env.SLACK_ADMIN_USER_TOKEN;
 
+      let whoCanCreatePrivateChannels = "admin"; // デフォルト: 承認が必要
+      let isEveryoneAllowed = false;
+
       if (!adminToken) {
-        throw new Error(t("errors.missing_admin_token"));
+        // Admin Tokenがない場合はデフォルト値を使用
+        console.warn(
+          "SLACK_ADMIN_USER_TOKEN is not set. " +
+            "Falling back to default: approval required.",
+        );
+      } else {
+        try {
+          // ワークスペースの team_id を取得
+          const teamId = await getWorkspaceTeamId(client, channelId);
+
+          // Admin API でワークスペース設定を取得
+          const settings = await getTeamSettings(adminToken, teamId);
+
+          whoCanCreatePrivateChannels =
+            settings.who_can_create_private_channels;
+          isEveryoneAllowed = whoCanCreatePrivateChannels === "everyone";
+
+          if (settings.api_error) {
+            console.log(
+              `Note: API returned error '${settings.api_error}', using default permission setting.`,
+            );
+          }
+        } catch (apiError) {
+          // API呼び出しに失敗した場合もデフォルト値を使用
+          const errorMsg = apiError instanceof Error
+            ? apiError.message
+            : `${apiError}`;
+          console.warn(
+            `Failed to check permissions: ${errorMsg}. ` +
+              `Falling back to default: approval required.`,
+          );
+        }
       }
 
-      // ワークスペースの team_id を取得
-      const teamId = await getWorkspaceTeamId(client, channelId);
-
-      // Admin API でワークスペース設定を取得
-      const settings = await getTeamSettings(adminToken, teamId);
-
-      const whoCanCreatePrivateChannels =
-        settings.who_can_create_private_channels;
-      const isEveryoneAllowed = whoCanCreatePrivateChannels === "everyone";
-
       console.log(
-        t("logs.private_channel_permissions_checked", {
-          permission: whoCanCreatePrivateChannels,
-          isEveryoneAllowed: isEveryoneAllowed.toString(),
-        }),
+        `Private channel permissions checked: ${whoCanCreatePrivateChannels} ` +
+          `(everyone allowed: ${isEveryoneAllowed})`,
       );
 
       return {

--- a/functions/check_private_channel_permissions/mod.ts
+++ b/functions/check_private_channel_permissions/mod.ts
@@ -1,0 +1,206 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+import { channelIdSchema } from "../../lib/validation/schemas.ts";
+
+// i18nを初期化
+await initI18n();
+
+/**
+ * admin.teams.settings.info APIのレスポンス型
+ */
+interface AdminTeamsSettingsInfoResponse {
+  ok: boolean;
+  team?: {
+    id: string;
+    name?: string;
+    domain?: string;
+    default_channels?: string[];
+    who_can_create_private_channels?: string;
+  };
+  error?: string;
+}
+
+/**
+ * プライベートチャンネル作成権限を確認する関数の定義
+ *
+ * Admin API (admin.teams.settings.info) を使用して、
+ * ワークスペースのプライベートチャンネル作成権限設定を取得します。
+ */
+export const CheckPrivateChannelPermissionsDefinition = DefineFunction({
+  callback_id: "check_private_channel_permissions",
+  title: "プライベートチャンネル作成権限確認",
+  description:
+    "ワークスペースのプライベートチャンネル作成権限設定を確認します",
+  source_file: "functions/check_private_channel_permissions/mod.ts",
+  input_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "インタラクティブコンテキスト（出力に渡されます）",
+      },
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description: "team_id取得用チャンネルID（Enterprise Grid用）",
+      },
+    },
+    required: ["interactivity", "channel_id"],
+  },
+  output_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "インタラクティブコンテキスト（入力から引き継ぎ）",
+      },
+      who_can_create_private_channels: {
+        type: Schema.types.string,
+        description:
+          "プライベートチャンネル作成権限（everyone, admin, ownerなど）",
+      },
+      is_everyone_allowed: {
+        type: Schema.types.boolean,
+        description: "全員がプライベートチャンネルを作成可能かどうか",
+      },
+    },
+    required: ["interactivity", "who_can_create_private_channels", "is_everyone_allowed"],
+  },
+});
+
+/**
+ * ワークスペースの team_id を取得します
+ *
+ * @param client - Slack APIクライアント
+ * @param channelId - チャンネルID
+ * @returns ワークスペースのteam_id
+ * @throws {Error} チャンネル情報の取得に失敗した場合
+ */
+async function getWorkspaceTeamId(
+  // deno-lint-ignore no-explicit-any
+  client: any,
+  channelId: string,
+): Promise<string> {
+  const response = await client.conversations.info({ channel: channelId });
+
+  if (!response.ok || !response.channel) {
+    throw new Error(
+      t("errors.channel_info_failed", {
+        error: response.error ?? t("errors.unknown_error"),
+      }),
+    );
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const teamId = (response.channel as any).context_team_id as string;
+
+  if (!teamId) {
+    throw new Error(t("errors.missing_team_id"));
+  }
+
+  return teamId;
+}
+
+/**
+ * Admin API を使用してワークスペースの設定を取得します
+ *
+ * @param adminToken - 管理者のユーザートークン（xoxp-...）
+ * @param teamId - ワークスペースのチームID
+ * @returns ワークスペース設定情報
+ * @throws {Error} APIリクエストに失敗した場合
+ *
+ * @example
+ * ```typescript
+ * const settings = await getTeamSettings(adminToken, teamId);
+ * console.log(settings.who_can_create_private_channels); // "everyone" | "admin" | "owner"
+ * ```
+ */
+export async function getTeamSettings(
+  adminToken: string,
+  teamId: string,
+): Promise<{ who_can_create_private_channels: string }> {
+  console.log(t("logs.fetching_team_settings", { teamId }));
+
+  const params = new URLSearchParams({
+    team_id: teamId,
+  });
+
+  const response = await fetch(
+    `https://slack.com/api/admin.teams.settings.info?${params.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${adminToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+    },
+  );
+
+  const result: AdminTeamsSettingsInfoResponse = await response.json();
+
+  console.log("admin.teams.settings.info response:", {
+    ok: result.ok,
+    error: result.error,
+    who_can_create_private_channels:
+      result.team?.who_can_create_private_channels,
+  });
+
+  if (!result.ok) {
+    throw new Error(
+      t("errors.fetch_team_settings_failed", {
+        error: result.error ?? t("errors.unknown_error"),
+      }),
+    );
+  }
+
+  // デフォルトは "admin"（制限あり）として扱う
+  const whoCanCreatePrivateChannels =
+    result.team?.who_can_create_private_channels ?? "admin";
+
+  return {
+    who_can_create_private_channels: whoCanCreatePrivateChannels,
+  };
+}
+
+export default SlackFunction(
+  CheckPrivateChannelPermissionsDefinition,
+  async ({ inputs, client, env }) => {
+    try {
+      // バリデーション
+      const channelId = channelIdSchema.parse(inputs.channel_id);
+
+      // 環境変数から Admin User Token を取得
+      const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+
+      if (!adminToken) {
+        throw new Error(t("errors.missing_admin_token"));
+      }
+
+      // ワークスペースの team_id を取得
+      const teamId = await getWorkspaceTeamId(client, channelId);
+
+      // Admin API でワークスペース設定を取得
+      const settings = await getTeamSettings(adminToken, teamId);
+
+      const whoCanCreatePrivateChannels =
+        settings.who_can_create_private_channels;
+      const isEveryoneAllowed = whoCanCreatePrivateChannels === "everyone";
+
+      console.log(
+        t("logs.private_channel_permissions_checked", {
+          permission: whoCanCreatePrivateChannels,
+          isEveryoneAllowed: isEveryoneAllowed.toString(),
+        }),
+      );
+
+      return {
+        outputs: {
+          interactivity: inputs.interactivity,
+          who_can_create_private_channels: whoCanCreatePrivateChannels,
+          is_everyone_allowed: isEveryoneAllowed,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      console.error("Function error:", message);
+      return { error: message };
+    }
+  },
+);

--- a/functions/check_private_channel_permissions/test.ts
+++ b/functions/check_private_channel_permissions/test.ts
@@ -1,0 +1,100 @@
+import { assertEquals, assertRejects } from "std/testing/asserts.ts";
+import { getTeamSettings } from "./mod.ts";
+
+/**
+ * getTeamSettings関数のテスト
+ */
+Deno.test("getTeamSettings: 正常にワークスペース設定を取得できる（everyone）", async () => {
+  // モックのfetch関数を設定
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async () => {
+    return {
+      json: async () => ({
+        ok: true,
+        team: {
+          id: "T12345",
+          name: "test-workspace",
+          who_can_create_private_channels: "everyone",
+        },
+      }),
+    };
+  }) as typeof fetch;
+
+  try {
+    const result = await getTeamSettings("xoxp-test-token", "T12345");
+    assertEquals(result.who_can_create_private_channels, "everyone");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("getTeamSettings: 正常にワークスペース設定を取得できる（admin）", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async () => {
+    return {
+      json: async () => ({
+        ok: true,
+        team: {
+          id: "T12345",
+          name: "test-workspace",
+          who_can_create_private_channels: "admin",
+        },
+      }),
+    };
+  }) as typeof fetch;
+
+  try {
+    const result = await getTeamSettings("xoxp-test-token", "T12345");
+    assertEquals(result.who_can_create_private_channels, "admin");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("getTeamSettings: フィールドがない場合はデフォルト値を返す", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async () => {
+    return {
+      json: async () => ({
+        ok: true,
+        team: {
+          id: "T12345",
+          name: "test-workspace",
+          // who_can_create_private_channels フィールドがない
+        },
+      }),
+    };
+  }) as typeof fetch;
+
+  try {
+    const result = await getTeamSettings("xoxp-test-token", "T12345");
+    assertEquals(result.who_can_create_private_channels, "admin");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("getTeamSettings: APIエラー時は例外をスローする", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async () => {
+    return {
+      json: async () => ({
+        ok: false,
+        error: "team_not_found",
+      }),
+    };
+  }) as typeof fetch;
+
+  try {
+    await assertRejects(
+      () => getTeamSettings("xoxp-test-token", "T12345"),
+      Error,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/functions/check_private_channel_permissions/test.ts
+++ b/functions/check_private_channel_permissions/test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "std/testing/asserts.ts";
+import { assertEquals } from "std/testing/asserts.ts";
 import { getTeamSettings } from "./mod.ts";
 
 // fetch のモック用グローバル変数
@@ -93,7 +93,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "getTeamSettings: APIエラー時は例外をスローする",
+  name: "getTeamSettings: APIエラー時はデフォルト値を返す",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -107,10 +107,35 @@ Deno.test({
       } as Response);
 
     try {
-      await assertRejects(
-        () => getTeamSettings("xoxp-test-token", "T12345"),
-        Error,
-      );
+      const result = await getTeamSettings("xoxp-test-token", "T12345");
+      // APIエラー時はデフォルト値（admin）を返す
+      assertEquals(result.who_can_create_private_channels, "admin");
+      assertEquals(result.api_error, "team_not_found");
+    } finally {
+      restoreFetch();
+    }
+  },
+});
+
+Deno.test({
+  name: "getTeamSettings: missing_scopeエラー時もデフォルト値を返す",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: false,
+            error: "missing_scope",
+          }),
+      } as Response);
+
+    try {
+      const result = await getTeamSettings("xoxp-test-token", "T12345");
+      // missing_scopeエラー時はデフォルト値（admin）を返す
+      assertEquals(result.who_can_create_private_channels, "admin");
+      assertEquals(result.api_error, "missing_scope");
     } finally {
       restoreFetch();
     }

--- a/functions/check_private_channel_permissions/test.ts
+++ b/functions/check_private_channel_permissions/test.ts
@@ -1,100 +1,118 @@
 import { assertEquals, assertRejects } from "std/testing/asserts.ts";
 import { getTeamSettings } from "./mod.ts";
 
+// fetch のモック用グローバル変数
+const originalFetch = globalThis.fetch;
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch;
+}
+
 /**
  * getTeamSettings関数のテスト
  */
-Deno.test("getTeamSettings: 正常にワークスペース設定を取得できる（everyone）", async () => {
-  // モックのfetch関数を設定
-  const originalFetch = globalThis.fetch;
+Deno.test({
+  name: "getTeamSettings: 正常にワークスペース設定を取得できる（everyone）",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            team: {
+              id: "T12345",
+              name: "test-workspace",
+              who_can_create_private_channels: "everyone",
+            },
+          }),
+      } as Response);
 
-  globalThis.fetch = (async () => {
-    return {
-      json: async () => ({
-        ok: true,
-        team: {
-          id: "T12345",
-          name: "test-workspace",
-          who_can_create_private_channels: "everyone",
-        },
-      }),
-    };
-  }) as typeof fetch;
-
-  try {
-    const result = await getTeamSettings("xoxp-test-token", "T12345");
-    assertEquals(result.who_can_create_private_channels, "everyone");
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    try {
+      const result = await getTeamSettings("xoxp-test-token", "T12345");
+      assertEquals(result.who_can_create_private_channels, "everyone");
+    } finally {
+      restoreFetch();
+    }
+  },
 });
 
-Deno.test("getTeamSettings: 正常にワークスペース設定を取得できる（admin）", async () => {
-  const originalFetch = globalThis.fetch;
+Deno.test({
+  name: "getTeamSettings: 正常にワークスペース設定を取得できる（admin）",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            team: {
+              id: "T12345",
+              name: "test-workspace",
+              who_can_create_private_channels: "admin",
+            },
+          }),
+      } as Response);
 
-  globalThis.fetch = (async () => {
-    return {
-      json: async () => ({
-        ok: true,
-        team: {
-          id: "T12345",
-          name: "test-workspace",
-          who_can_create_private_channels: "admin",
-        },
-      }),
-    };
-  }) as typeof fetch;
-
-  try {
-    const result = await getTeamSettings("xoxp-test-token", "T12345");
-    assertEquals(result.who_can_create_private_channels, "admin");
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    try {
+      const result = await getTeamSettings("xoxp-test-token", "T12345");
+      assertEquals(result.who_can_create_private_channels, "admin");
+    } finally {
+      restoreFetch();
+    }
+  },
 });
 
-Deno.test("getTeamSettings: フィールドがない場合はデフォルト値を返す", async () => {
-  const originalFetch = globalThis.fetch;
+Deno.test({
+  name: "getTeamSettings: フィールドがない場合はデフォルト値を返す",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            team: {
+              id: "T12345",
+              name: "test-workspace",
+              // who_can_create_private_channels フィールドがない
+            },
+          }),
+      } as Response);
 
-  globalThis.fetch = (async () => {
-    return {
-      json: async () => ({
-        ok: true,
-        team: {
-          id: "T12345",
-          name: "test-workspace",
-          // who_can_create_private_channels フィールドがない
-        },
-      }),
-    };
-  }) as typeof fetch;
-
-  try {
-    const result = await getTeamSettings("xoxp-test-token", "T12345");
-    assertEquals(result.who_can_create_private_channels, "admin");
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    try {
+      const result = await getTeamSettings("xoxp-test-token", "T12345");
+      assertEquals(result.who_can_create_private_channels, "admin");
+    } finally {
+      restoreFetch();
+    }
+  },
 });
 
-Deno.test("getTeamSettings: APIエラー時は例外をスローする", async () => {
-  const originalFetch = globalThis.fetch;
+Deno.test({
+  name: "getTeamSettings: APIエラー時は例外をスローする",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    globalThis.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ok: false,
+            error: "team_not_found",
+          }),
+      } as Response);
 
-  globalThis.fetch = (async () => {
-    return {
-      json: async () => ({
-        ok: false,
-        error: "team_not_found",
-      }),
-    };
-  }) as typeof fetch;
-
-  try {
-    await assertRejects(
-      () => getTeamSettings("xoxp-test-token", "T12345"),
-      Error,
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    try {
+      await assertRejects(
+        () => getTeamSettings("xoxp-test-token", "T12345"),
+        Error,
+      );
+    } finally {
+      restoreFetch();
+    }
+  },
 });

--- a/functions/get_authorized_users/mod.ts
+++ b/functions/get_authorized_users/mod.ts
@@ -57,23 +57,15 @@ export const GetAuthorizedUsersDefinition = DefineFunction({
   source_file: "functions/get_authorized_users/mod.ts",
   input_parameters: {
     properties: {
-      interactivity: {
-        type: Schema.slack.types.interactivity,
-        description: "インタラクティブコンテキスト（出力に渡されます）",
-      },
       channel_id: {
         type: Schema.slack.types.channel_id,
         description: "team_id取得用チャンネルID（Enterprise Grid用）",
       },
     },
-    required: ["interactivity", "channel_id"],
+    required: ["channel_id"],
   },
   output_parameters: {
     properties: {
-      interactivity: {
-        type: Schema.slack.types.interactivity,
-        description: "インタラクティブコンテキスト（入力から引き継ぎ）",
-      },
       authorized_users: {
         type: Schema.types.array,
         items: {
@@ -91,7 +83,7 @@ export const GetAuthorizedUsersDefinition = DefineFunction({
         description: "権限ユーザー数",
       },
     },
-    required: ["interactivity", "authorized_users", "user_ids", "count"],
+    required: ["authorized_users", "user_ids", "count"],
   },
 });
 
@@ -277,7 +269,6 @@ export default SlackFunction(
 
       return {
         outputs: {
-          interactivity: inputs.interactivity,
           authorized_users: authorizedUsers,
           user_ids: userIds,
           count: authorizedUsers.length,

--- a/functions/show_loading_modal/mod.ts
+++ b/functions/show_loading_modal/mod.ts
@@ -1,0 +1,122 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+
+// i18nを初期化
+await initI18n();
+
+/**
+ * ローディングモーダルを表示する関数の定義
+ *
+ * インタラクティブトークンが期限切れになる前に、即座にモーダルを表示します。
+ * その後、views.updateで本来のフォームに更新することで、
+ * 処理時間が長くてもモーダルを表示できます。
+ */
+export const ShowLoadingModalDefinition = DefineFunction({
+  callback_id: "show_loading_modal",
+  title: "ローディングモーダル表示",
+  description: "処理中であることを示すローディングモーダルを表示します",
+  source_file: "functions/show_loading_modal/mod.ts",
+  input_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "インタラクティブコンテキスト",
+      },
+      user_id: {
+        type: Schema.slack.types.user_id,
+        description: "リクエストを行ったユーザーのID",
+      },
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description: "リクエストが行われたチャンネルのID",
+      },
+    },
+    required: ["interactivity", "user_id", "channel_id"],
+  },
+  output_parameters: {
+    properties: {
+      view_id: {
+        type: Schema.types.string,
+        description: "表示されたモーダルのview_id（後続でupdateに使用）",
+      },
+      user_id: {
+        type: Schema.slack.types.user_id,
+        description: "リクエストを行ったユーザーのID（パススルー）",
+      },
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description: "リクエストが行われたチャンネルのID（パススルー）",
+      },
+    },
+    required: ["view_id", "user_id", "channel_id"],
+  },
+});
+
+export default SlackFunction(
+  ShowLoadingModalDefinition,
+  async ({ inputs, client }) => {
+    try {
+      console.log("Opening loading modal...");
+
+      // ローディングモーダルを即座に表示
+      const response = await client.views.open({
+        interactivity_pointer: inputs.interactivity.interactivity_pointer,
+        view: {
+          type: "modal",
+          callback_id: "loading_modal",
+          notify_on_close: false,
+          title: {
+            type: "plain_text",
+            text: t("form.loading_title"),
+          },
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: t("form.loading_message"),
+              },
+            },
+            {
+              type: "context",
+              elements: [
+                {
+                  type: "mrkdwn",
+                  text: t("form.loading_hint"),
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      if (!response.ok) {
+        console.error("Failed to open loading modal:", response.error);
+        throw new Error(
+          t("errors.modal_open_failed", {
+            error: response.error ?? t("errors.unknown_error"),
+          }),
+        );
+      }
+
+      const viewId = response.view?.id;
+      if (!viewId) {
+        throw new Error(t("errors.view_id_not_found"));
+      }
+
+      console.log("Loading modal opened successfully:", { viewId });
+
+      return {
+        outputs: {
+          view_id: viewId,
+          user_id: inputs.user_id,
+          channel_id: inputs.channel_id,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      console.error("Function error:", message);
+      return { error: message };
+    }
+  },
+);

--- a/functions/show_loading_modal/test.ts
+++ b/functions/show_loading_modal/test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "std/testing/asserts.ts";
+import { ShowLoadingModalDefinition } from "./mod.ts";
+
+/**
+ * ShowLoadingModalDefinition のテスト
+ */
+Deno.test("ShowLoadingModalDefinition: 関数定義がエクスポートされている", () => {
+  // 関数定義が正しくエクスポートされていることを確認
+  assertEquals(typeof ShowLoadingModalDefinition, "object");
+  assertEquals(ShowLoadingModalDefinition !== null, true);
+});
+
+Deno.test("ShowLoadingModalDefinition: definitionプロパティが存在する", () => {
+  // deno-lint-ignore no-explicit-any
+  const def = ShowLoadingModalDefinition as any;
+  // 定義オブジェクトが存在することを確認
+  assertEquals("definition" in def || "id" in def, true);
+});

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -54,8 +54,12 @@ export const ShowPrivateChannelFormDefinition = DefineFunction({
         },
         description: "承認権限を持つユーザー一覧",
       },
+      is_everyone_allowed: {
+        type: Schema.types.boolean,
+        description: "全員がプライベートチャンネルを作成可能かどうか",
+      },
     },
-    required: ["interactivity", "user_id", "channel_id", "authorized_users"],
+    required: ["interactivity", "user_id", "channel_id", "authorized_users", "is_everyone_allowed"],
   },
   output_parameters: {
     properties: {
@@ -164,6 +168,34 @@ async function getWorkspaceTeamId(
 }
 
 /**
+ * Admin API を使用してメンバーを招待します
+ */
+async function inviteMembersWithAdminApi(
+  adminToken: string,
+  channelId: string,
+  userIds: string[],
+): Promise<{ ok: boolean; error?: string }> {
+  if (userIds.length === 0) {
+    return { ok: true };
+  }
+  const response = await fetch(
+    "https://slack.com/api/admin.conversations.invite",
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${adminToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        channel_id: channelId,
+        user_ids: userIds.join(","),
+      }),
+    },
+  );
+  return await response.json();
+}
+
+/**
  * 承認者選択のオプションを生成します
  */
 function buildApproverOptions(authorizedUsers: AuthorizedUser[]) {
@@ -195,6 +227,7 @@ export default SlackFunction(
       const authorizedUsers = inputs.authorized_users as AuthorizedUser[];
       const channelId = inputs.channel_id as string;
       const userId = inputs.user_id as string;
+      const isEveryoneAllowed = inputs.is_everyone_allowed as boolean;
 
       // 権限ユーザーがいない場合はエラー
       if (!authorizedUsers || authorizedUsers.length === 0) {
@@ -234,6 +267,7 @@ export default SlackFunction(
           private_metadata: JSON.stringify({
             channel_id: channelId,
             user_id: userId,
+            is_everyone_allowed: isEveryoneAllowed,
           }),
           blocks: [
             {
@@ -342,13 +376,14 @@ export default SlackFunction(
   // モーダル送信時のハンドラー
   .addViewSubmissionHandler(
     ["private_channel_request_modal"],
-    async ({ view, body: _body, client }) => {
+    async ({ view, body: _body, client, env }) => {
       console.log("=== Modal submitted ===");
 
       // private_metadataから情報を取得
       const metadata = JSON.parse(view.private_metadata || "{}");
       const approvalChannelId = metadata.channel_id;
       const requesterId = metadata.user_id;
+      const isEveryoneAllowed = metadata.is_everyone_allowed === true;
 
       // フォーム入力値を取得
       const values = view.state.values;
@@ -367,6 +402,7 @@ export default SlackFunction(
         approverId,
         description,
         initialMembersCount: initialMembers.length,
+        isEveryoneAllowed,
       });
 
       try {
@@ -394,7 +430,100 @@ export default SlackFunction(
 
         const descriptionText = description || t("messages.no_description");
 
-        // 承認リクエストメッセージを送信
+        // 全員がプライベートチャンネルを作成可能な場合は、承認なしで直接作成
+        if (isEveryoneAllowed) {
+          console.log(
+            "Everyone is allowed to create private channels - creating directly",
+          );
+
+          const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+          if (!adminToken) {
+            throw new Error(t("errors.missing_admin_token"));
+          }
+
+          const teamId = await getWorkspaceTeamId(client, approvalChannelId);
+
+          console.log(t("logs.creating_channel_admin_api", { name: normalizedName }));
+
+          // Admin API でプライベートチャンネルを作成
+          const createResult = await createPrivateChannelWithAdminApi(
+            adminToken,
+            normalizedName,
+            teamId,
+            description,
+          );
+
+          if (!createResult.ok) {
+            throw new Error(
+              t("errors.channel_create_failed", {
+                error: createResult.error || t("errors.unknown_error"),
+              }),
+            );
+          }
+
+          const newChannelId = createResult.channel_id!;
+          console.log(t("logs.channel_created_private", { id: newChannelId }));
+
+          // メンバー招待（Admin API使用）
+          const allMembersToInvite = [requesterId];
+          // 承認者をチャンネルに参加させる（承認不要でも必ず参加）
+          if (validatedApproverId && !allMembersToInvite.includes(validatedApproverId)) {
+            allMembersToInvite.push(validatedApproverId);
+          }
+          for (const member of initialMembers) {
+            if (!allMembersToInvite.includes(member)) {
+              allMembersToInvite.push(member);
+            }
+          }
+
+          console.log(t("logs.inviting_members", { count: allMembersToInvite.length }));
+          try {
+            const inviteResult = await inviteMembersWithAdminApi(
+              adminToken,
+              newChannelId,
+              allMembersToInvite,
+            );
+            if (!inviteResult.ok) {
+              console.error("Failed to invite members:", inviteResult.error);
+            }
+          } catch (inviteError) {
+            console.error("Failed to invite members:", inviteError);
+          }
+
+          // 作成完了メッセージを送信
+          await client.chat.postMessage({
+            channel: approvalChannelId,
+            text: t("messages.channel_created_directly", { channel: normalizedName }),
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: t("messages.channel_created_directly_details", {
+                    channel: normalizedName,
+                    channel_id: newChannelId,
+                    requester: requesterId,
+                    participant: validatedApproverId,
+                  }),
+                },
+              },
+              {
+                type: "context",
+                elements: [
+                  {
+                    type: "mrkdwn",
+                    text: `${t("messages.created_at", { time: new Date().toISOString() })}`,
+                  },
+                ],
+              },
+            ],
+          });
+
+          // モーダルを閉じる
+          return;
+        }
+
+        // 承認が必要な場合は承認リクエストメッセージを送信
         await client.chat.postMessage({
           channel: approvalChannelId,
           text: t("messages.approval_request_title", {

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -35,9 +35,10 @@ export const ShowPrivateChannelFormDefinition = DefineFunction({
   source_file: "functions/show_private_channel_form/mod.ts",
   input_parameters: {
     properties: {
-      interactivity: {
-        type: Schema.slack.types.interactivity,
-        description: "モーダルを開くためのインタラクティブコンテキスト",
+      view_id: {
+        type: Schema.types.string,
+        description:
+          "更新対象のモーダルview_id（ローディングモーダルから渡される）",
       },
       user_id: {
         type: Schema.slack.types.user_id,
@@ -60,7 +61,7 @@ export const ShowPrivateChannelFormDefinition = DefineFunction({
       },
     },
     required: [
-      "interactivity",
+      "view_id",
       "user_id",
       "channel_id",
       "authorized_users",
@@ -234,6 +235,7 @@ export default SlackFunction(
       const channelId = inputs.channel_id as string;
       const userId = inputs.user_id as string;
       const isEveryoneAllowed = inputs.is_everyone_allowed as boolean;
+      const viewId = inputs.view_id as string;
 
       // 権限ユーザーがいない場合はエラー
       if (!authorizedUsers || authorizedUsers.length === 0) {
@@ -249,9 +251,9 @@ export default SlackFunction(
         }),
       );
 
-      // カスタムモーダルを開く
-      const viewResult = await client.views.open({
-        interactivity_pointer: inputs.interactivity.interactivity_pointer,
+      // ローディングモーダルを本来のフォームに更新
+      const viewResult = await client.views.update({
+        view_id: viewId,
         view: {
           type: "modal",
           callback_id: "private_channel_request_modal",
@@ -362,7 +364,7 @@ export default SlackFunction(
 
       if (!viewResult.ok) {
         throw new Error(
-          t("errors.modal_open_failed", {
+          t("errors.modal_update_failed", {
             error: viewResult.error ?? t("errors.unknown_error"),
           }),
         );

--- a/functions/show_private_channel_form/mod.ts
+++ b/functions/show_private_channel_form/mod.ts
@@ -59,7 +59,13 @@ export const ShowPrivateChannelFormDefinition = DefineFunction({
         description: "全員がプライベートチャンネルを作成可能かどうか",
       },
     },
-    required: ["interactivity", "user_id", "channel_id", "authorized_users", "is_everyone_allowed"],
+    required: [
+      "interactivity",
+      "user_id",
+      "channel_id",
+      "authorized_users",
+      "is_everyone_allowed",
+    ],
   },
   output_parameters: {
     properties: {
@@ -443,7 +449,9 @@ export default SlackFunction(
 
           const teamId = await getWorkspaceTeamId(client, approvalChannelId);
 
-          console.log(t("logs.creating_channel_admin_api", { name: normalizedName }));
+          console.log(
+            t("logs.creating_channel_admin_api", { name: normalizedName }),
+          );
 
           // Admin API でプライベートチャンネルを作成
           const createResult = await createPrivateChannelWithAdminApi(
@@ -467,7 +475,10 @@ export default SlackFunction(
           // メンバー招待（Admin API使用）
           const allMembersToInvite = [requesterId];
           // 承認者をチャンネルに参加させる（承認不要でも必ず参加）
-          if (validatedApproverId && !allMembersToInvite.includes(validatedApproverId)) {
+          if (
+            validatedApproverId &&
+            !allMembersToInvite.includes(validatedApproverId)
+          ) {
             allMembersToInvite.push(validatedApproverId);
           }
           for (const member of initialMembers) {
@@ -476,7 +487,9 @@ export default SlackFunction(
             }
           }
 
-          console.log(t("logs.inviting_members", { count: allMembersToInvite.length }));
+          console.log(
+            t("logs.inviting_members", { count: allMembersToInvite.length }),
+          );
           try {
             const inviteResult = await inviteMembersWithAdminApi(
               adminToken,
@@ -493,7 +506,9 @@ export default SlackFunction(
           // 作成完了メッセージを送信
           await client.chat.postMessage({
             channel: approvalChannelId,
-            text: t("messages.channel_created_directly", { channel: normalizedName }),
+            text: t("messages.channel_created_directly", {
+              channel: normalizedName,
+            }),
             blocks: [
               {
                 type: "section",
@@ -512,7 +527,11 @@ export default SlackFunction(
                 elements: [
                   {
                     type: "mrkdwn",
-                    text: `${t("messages.created_at", { time: new Date().toISOString() })}`,
+                    text: `${
+                      t("messages.created_at", {
+                        time: new Date().toISOString(),
+                      })
+                    }`,
                   },
                 ],
               },

--- a/lib/i18n/mod.ts
+++ b/lib/i18n/mod.ts
@@ -47,6 +47,8 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       no_authorized_users:
         "No authorized users found. Please ensure there are admins or owners in the workspace.",
       modal_open_failed: "Failed to open the form: {error}",
+      modal_update_failed: "Failed to update the form: {error}",
+      view_id_not_found: "View ID not found in response",
       not_authorized_approver:
         "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
       validation: {
@@ -101,6 +103,10 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       description_placeholder: "What is this channel for?",
       initial_members_label: "Initial Members",
       initial_members_placeholder: "Select members to invite",
+      loading_title: "Please wait...",
+      loading_message:
+        "⏳ *Loading form...*\n\nPreparing your private channel request form.",
+      loading_hint: "This may take a few seconds.",
     },
     logs: {
       starting: "Starting workflow...",
@@ -157,6 +163,8 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       no_authorized_users:
         "認可ユーザーが見つかりません。ワークスペースに管理者またはオーナーがいることを確認してください。",
       modal_open_failed: "フォームを開くことができませんでした: {error}",
+      modal_update_failed: "フォームの更新に失敗しました: {error}",
+      view_id_not_found: "レスポンスにview_idが見つかりません",
       not_authorized_approver:
         "⚠️ このリクエストを承認する権限がありません。<@{approver}> のみが承認または拒否できます。",
       validation: {
@@ -212,6 +220,10 @@ const EMBEDDED_LOCALES: Record<string, LocaleData> = {
       description_placeholder: "このチャンネルの目的は？",
       initial_members_label: "初期メンバー",
       initial_members_placeholder: "招待するメンバーを選択してください",
+      loading_title: "少々お待ちください...",
+      loading_message:
+        "⏳ *フォームを準備中...*\n\nプライベートチャンネルリクエストフォームを準備しています。",
+      loading_hint: "数秒お待ちください。",
     },
     logs: {
       starting: "ワークフローを開始しています...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -18,6 +18,7 @@
     "channel_info_failed": "Failed to get channel info: {error}",
     "missing_notification_channel": "Notification channel ID is required",
     "missing_admin_token": "Admin user token (SLACK_ADMIN_USER_TOKEN) is not configured",
+    "fetch_team_settings_failed": "Failed to fetch team settings: {error}",
     "fetch_authorized_users_failed": "Failed to fetch authorized users: {error}",
     "no_authorized_users": "No authorized users found. Please ensure there are admins or owners in the workspace.",
     "modal_open_failed": "Failed to open the form: {error}",
@@ -50,7 +51,10 @@
     "channel_denied": "❌ *Private channel request denied*\n\n*Channel:* `#{channel}`\n*Denied by:* <@{reviewer}>\n*Requested by:* <@{requester}>",
     "channel_creation_failed": "⚠️ *Failed to create private channel*\n\n*Channel:* `#{channel}`\n*Error:* {error}",
     "approved_at": "Approved at {time}",
-    "denied_at": "Denied at {time}"
+    "denied_at": "Denied at {time}",
+    "created_at": "Created at {time}",
+    "channel_created_directly": "Private channel #{channel} created",
+    "channel_created_directly_details": "🔒 *Private channel created!*\n\n*Channel:* <#{channel_id}|{channel}>\n*Created by:* <@{requester}>\n*Participant:* <@{participant}>"
   },
   "form": {
     "title": "Request Private Channel",
@@ -81,6 +85,8 @@
     "approval_request_sent": "Approval request sent successfully",
     "creating_channel_after_approval": "Creating channel '{name}' after approval",
     "members_invited": "{count} members invited to the channel",
+    "fetching_team_settings": "Fetching team settings for team: {teamId}",
+    "private_channel_permissions_checked": "Private channel permissions checked: {permission} (everyone allowed: {isEveryoneAllowed})",
     "fetching_authorized_users": "Fetching authorized users for team: {teamId}",
     "authorized_users_fetched": "Found {count} authorized users (admins/owners)",
     "opening_form_with_authorized_users": "Opening form with {count} authorized users",

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,6 +22,8 @@
     "fetch_authorized_users_failed": "Failed to fetch authorized users: {error}",
     "no_authorized_users": "No authorized users found. Please ensure there are admins or owners in the workspace.",
     "modal_open_failed": "Failed to open the form: {error}",
+    "modal_update_failed": "Failed to update the form: {error}",
+    "view_id_not_found": "View ID not found in response",
     "not_authorized_approver": "⚠️ You are not authorized to approve this request. Only <@{approver}> can approve or deny.",
     "validation": {
       "channel_id_empty": "Channel ID cannot be empty",
@@ -69,7 +71,10 @@
     "description_label": "Description",
     "description_placeholder": "What is this channel for?",
     "initial_members_label": "Initial Members",
-    "initial_members_placeholder": "Select members to invite"
+    "initial_members_placeholder": "Select members to invite",
+    "loading_title": "Please wait...",
+    "loading_message": "⏳ *Loading form...*\n\nPreparing your private channel request form.",
+    "loading_hint": "This may take a few seconds."
   },
   "logs": {
     "starting": "Starting workflow...",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -22,6 +22,8 @@
     "fetch_authorized_users_failed": "認可されたユーザーの取得に失敗しました: {error}",
     "no_authorized_users": "認可されたユーザーが見つかりません。ワークスペースに管理者またはオーナーがいることを確認してください。",
     "modal_open_failed": "フォームを開くことに失敗しました: {error}",
+    "modal_update_failed": "フォームの更新に失敗しました: {error}",
+    "view_id_not_found": "レスポンスにview_idが見つかりません",
     "not_authorized_approver": "⚠️ このリクエストを承認する権限がありません。<@{approver}>のみが承認または却下できます。",
     "validation": {
       "channel_id_empty": "チャネルIDは空にできません",
@@ -69,7 +71,10 @@
     "description_label": "説明",
     "description_placeholder": "このチャネルの目的は?",
     "initial_members_label": "初期メンバー",
-    "initial_members_placeholder": "招待するメンバーを選択してください"
+    "initial_members_placeholder": "招待するメンバーを選択してください",
+    "loading_title": "少々お待ちください...",
+    "loading_message": "⏳ *フォームを準備中...*\n\nプライベートチャンネルリクエストフォームを準備しています。",
+    "loading_hint": "数秒お待ちください。"
   },
   "logs": {
     "starting": "ワークフローを開始しています...",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -18,6 +18,7 @@
     "channel_info_failed": "チャネル情報の取得に失敗しました: {error}",
     "missing_notification_channel": "通知チャネルIDが必要です",
     "missing_admin_token": "管理者ユーザートークン(SLACK_ADMIN_USER_TOKEN)が設定されていません",
+    "fetch_team_settings_failed": "チーム設定の取得に失敗しました: {error}",
     "fetch_authorized_users_failed": "認可されたユーザーの取得に失敗しました: {error}",
     "no_authorized_users": "認可されたユーザーが見つかりません。ワークスペースに管理者またはオーナーがいることを確認してください。",
     "modal_open_failed": "フォームを開くことに失敗しました: {error}",
@@ -50,7 +51,10 @@
     "channel_denied": "❌ *プライベートチャネルリクエストが却下されました*\n\n*チャネル:* `#{channel}`\n*却下者:* <@{reviewer}>\n*リクエスター:* <@{requester}>",
     "channel_creation_failed": "⚠️ *プライベートチャネルの作成に失敗しました*\n\n*チャネル:* `#{channel}`\n*エラー:* {error}",
     "approved_at": "{time}に承認されました",
-    "denied_at": "{time}に却下されました"
+    "denied_at": "{time}に却下されました",
+    "created_at": "{time}に作成されました",
+    "channel_created_directly": "プライベートチャンネル#{channel}が作成されました",
+    "channel_created_directly_details": "🔒 *プライベートチャンネルが作成されました!*\n\n*チャンネル:* <#{channel_id}|{channel}>\n*作成者:* <@{requester}>\n*参加者:* <@{participant}>"
   },
   "form": {
     "title": "プライベートチャネルをリクエスト",
@@ -81,6 +85,8 @@
     "approval_request_sent": "承認リクエストが正常に送信されました",
     "creating_channel_after_approval": "承認後、チャネル'{name}'を作成中",
     "members_invited": "{count}人のメンバーがチャネルに招待されました",
+    "fetching_team_settings": "チーム{teamId}の設定を取得中...",
+    "private_channel_permissions_checked": "プライベートチャンネル作成権限を確認しました: {permission} (全員許可: {isEveryoneAllowed})",
     "fetching_authorized_users": "チーム{teamId}の認可されたユーザーを取得中...",
     "authorized_users_fetched": "{count}人の認可されたユーザー(管理者/オーナー)が見つかりました",
     "opening_form_with_authorized_users": "{count}人の認可されたユーザーでフォームを開く",

--- a/manifest.ts
+++ b/manifest.ts
@@ -5,6 +5,7 @@ import { CreatePrivateChannelDefinition } from "./functions/create_private_chann
 import { RequestPrivateChannelDefinition } from "./functions/request_private_channel/mod.ts";
 import { GetAuthorizedUsersDefinition } from "./functions/get_authorized_users/mod.ts";
 import { ShowPrivateChannelFormDefinition } from "./functions/show_private_channel_form/mod.ts";
+import { CheckPrivateChannelPermissionsDefinition } from "./functions/check_private_channel_permissions/mod.ts";
 import CreateChannelWorkflow from "./workflows/create_channel_workflow.ts";
 import RequestPrivateChannelWorkflow from "./workflows/request_private_channel_workflow.ts";
 import ExampleWorkflow from "./workflows/example_workflow.ts";
@@ -34,6 +35,7 @@ export default Manifest({
     RequestPrivateChannelDefinition,
     GetAuthorizedUsersDefinition,
     ShowPrivateChannelFormDefinition,
+    CheckPrivateChannelPermissionsDefinition,
   ],
   outgoingDomains: [], // slack.com はデフォルトで許可済み
   botScopes: [

--- a/manifest.ts
+++ b/manifest.ts
@@ -6,6 +6,7 @@ import { RequestPrivateChannelDefinition } from "./functions/request_private_cha
 import { GetAuthorizedUsersDefinition } from "./functions/get_authorized_users/mod.ts";
 import { ShowPrivateChannelFormDefinition } from "./functions/show_private_channel_form/mod.ts";
 import { CheckPrivateChannelPermissionsDefinition } from "./functions/check_private_channel_permissions/mod.ts";
+import { ShowLoadingModalDefinition } from "./functions/show_loading_modal/mod.ts";
 import CreateChannelWorkflow from "./workflows/create_channel_workflow.ts";
 import RequestPrivateChannelWorkflow from "./workflows/request_private_channel_workflow.ts";
 import ExampleWorkflow from "./workflows/example_workflow.ts";
@@ -36,6 +37,7 @@ export default Manifest({
     GetAuthorizedUsersDefinition,
     ShowPrivateChannelFormDefinition,
     CheckPrivateChannelPermissionsDefinition,
+    ShowLoadingModalDefinition,
   ],
   outgoingDomains: [], // slack.com はデフォルトで許可済み
   botScopes: [

--- a/workflows/request_private_channel_workflow.ts
+++ b/workflows/request_private_channel_workflow.ts
@@ -1,6 +1,7 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
 import { GetAuthorizedUsersDefinition } from "../functions/get_authorized_users/mod.ts";
 import { ShowPrivateChannelFormDefinition } from "../functions/show_private_channel_form/mod.ts";
+import { CheckPrivateChannelPermissionsDefinition } from "../functions/check_private_channel_permissions/mod.ts";
 
 /**
  * プライベートチャンネル作成リクエストワークフロー
@@ -35,18 +36,29 @@ const RequestPrivateChannelWorkflow = DefineWorkflow({
   },
 });
 
-// Step 1: 権限を持つユーザー（管理者/オーナー）を取得
-// interactivityを入力として渡し、出力としてStep 2に引き継ぐ
-const getAuthorizedUsersStep = RequestPrivateChannelWorkflow.addStep(
-  GetAuthorizedUsersDefinition,
+// Step 1: プライベートチャンネル作成権限を確認
+// ワークスペースで誰がプライベートチャンネルを作成できるかを確認
+const checkPermissionsStep = RequestPrivateChannelWorkflow.addStep(
+  CheckPrivateChannelPermissionsDefinition,
   {
     interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
     channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
   },
 );
 
-// Step 2: フィルタリングされた承認者リストを使用してフォームを表示
+// Step 2: 権限を持つユーザー（管理者/オーナー）を取得
 // interactivityはStep 1の出力から取得
+const getAuthorizedUsersStep = RequestPrivateChannelWorkflow.addStep(
+  GetAuthorizedUsersDefinition,
+  {
+    interactivity: checkPermissionsStep.outputs.interactivity,
+    channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
+  },
+);
+
+// Step 3: フィルタリングされた承認者リストを使用してフォームを表示
+// interactivityはStep 2の出力から取得
+// is_everyone_allowed に基づいて、承認プロセスをスキップするかどうかを決定
 RequestPrivateChannelWorkflow.addStep(
   ShowPrivateChannelFormDefinition,
   {
@@ -54,6 +66,7 @@ RequestPrivateChannelWorkflow.addStep(
     user_id: RequestPrivateChannelWorkflow.inputs.user_id,
     channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
     authorized_users: getAuthorizedUsersStep.outputs.authorized_users,
+    is_everyone_allowed: checkPermissionsStep.outputs.is_everyone_allowed,
   },
 );
 

--- a/workflows/request_private_channel_workflow.ts
+++ b/workflows/request_private_channel_workflow.ts
@@ -1,7 +1,8 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { ShowLoadingModalDefinition } from "../functions/show_loading_modal/mod.ts";
+import { CheckPrivateChannelPermissionsDefinition } from "../functions/check_private_channel_permissions/mod.ts";
 import { GetAuthorizedUsersDefinition } from "../functions/get_authorized_users/mod.ts";
 import { ShowPrivateChannelFormDefinition } from "../functions/show_private_channel_form/mod.ts";
-import { CheckPrivateChannelPermissionsDefinition } from "../functions/check_private_channel_permissions/mod.ts";
 
 /**
  * プライベートチャンネル作成リクエストワークフロー
@@ -12,6 +13,11 @@ import { CheckPrivateChannelPermissionsDefinition } from "../functions/check_pri
  *
  * 承認者選択はプライベートチャンネル作成権限を持つユーザー
  * （管理者/オーナー）のみに制限されます。
+ *
+ * 処理の流れ:
+ * 1. ローディングモーダルを即座に表示（interactivityタイムアウト対策）
+ * 2. バックグラウンドで権限確認・ユーザー取得
+ * 3. モーダルを本来のフォームに更新
  */
 const RequestPrivateChannelWorkflow = DefineWorkflow({
   callback_id: "request_private_channel_workflow",
@@ -36,35 +42,42 @@ const RequestPrivateChannelWorkflow = DefineWorkflow({
   },
 });
 
-// Step 1: プライベートチャンネル作成権限を確認
+// Step 1: ローディングモーダルを即座に表示
+// interactivityトークンが期限切れになる前にモーダルを開く
+const showLoadingStep = RequestPrivateChannelWorkflow.addStep(
+  ShowLoadingModalDefinition,
+  {
+    interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
+    user_id: RequestPrivateChannelWorkflow.inputs.user_id,
+    channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
+  },
+);
+
+// Step 2: プライベートチャンネル作成権限を確認
 // ワークスペースで誰がプライベートチャンネルを作成できるかを確認
 const checkPermissionsStep = RequestPrivateChannelWorkflow.addStep(
   CheckPrivateChannelPermissionsDefinition,
   {
-    interactivity: RequestPrivateChannelWorkflow.inputs.interactivity,
     channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
   },
 );
 
-// Step 2: 権限を持つユーザー（管理者/オーナー）を取得
-// interactivityはStep 1の出力から取得
+// Step 3: 権限を持つユーザー（管理者/オーナー）を取得
 const getAuthorizedUsersStep = RequestPrivateChannelWorkflow.addStep(
   GetAuthorizedUsersDefinition,
   {
-    interactivity: checkPermissionsStep.outputs.interactivity,
     channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
   },
 );
 
-// Step 3: フィルタリングされた承認者リストを使用してフォームを表示
-// interactivityはStep 2の出力から取得
-// is_everyone_allowed に基づいて、承認プロセスをスキップするかどうかを決定
+// Step 4: ローディングモーダルを本来のフォームに更新
+// view_idを使ってviews.updateでモーダルを更新
 RequestPrivateChannelWorkflow.addStep(
   ShowPrivateChannelFormDefinition,
   {
-    interactivity: getAuthorizedUsersStep.outputs.interactivity,
-    user_id: RequestPrivateChannelWorkflow.inputs.user_id,
-    channel_id: RequestPrivateChannelWorkflow.inputs.channel_id,
+    view_id: showLoadingStep.outputs.view_id,
+    user_id: showLoadingStep.outputs.user_id,
+    channel_id: showLoadingStep.outputs.channel_id,
     authorized_users: getAuthorizedUsersStep.outputs.authorized_users,
     is_everyone_allowed: checkPermissionsStep.outputs.is_everyone_allowed,
   },


### PR DESCRIPTION
- check_private_channel_permissions関数を新規作成
  - admin.teams.settings.info APIで権限設定を取得
  - who_can_create_private_channelsフィールドを確認
- show_private_channel_formを修正
  - 全員が作成可能(everyone)の場合は承認プロセスをスキップ
  - 承認不要でも承認者は必ずチャンネルに参加
- ワークフローに権限チェックステップを追加
- i18nメッセージを追加（英語・日本語）

## 目的

<!-- 変更の背景や目的を簡潔に記述してください -->

## 変更内容

<!-- 主な変更点を箇条書きで記載してください -->

-

## 動作確認

<!-- 実施した確認内容を記載してください -->

- [ ] `deno task fmt`
- [ ] `deno task lint`
- [ ] `deno task check`
- [ ] `deno task test`
- [ ] Slack CLI によるローカル実行（必要に応じて）

## 影響範囲

<!-- 影響が予想される機能やドキュメントがあれば記載してください -->

## その他

<!-- レビュアーへの補足事項などがあれば記載してください -->
